### PR TITLE
Fix authentication screen freezing issue

### DIFF
--- a/src/components/providers/SessionProvider.tsx
+++ b/src/components/providers/SessionProvider.tsx
@@ -1,7 +1,8 @@
 'use client';
-import { createContext, useContext, ReactNode } from 'react';
+import { createContext, useContext, ReactNode, useEffect, useRef } from 'react';
 import { useSessionManager } from '@/hooks/useSessionManager';
-import { Session } from '@supabase/supabase-js'; 
+import { useAuthStore } from '@/stores/authStore';
+import { Session } from '@supabase/supabase-js';
 
 interface SessionContextType {
   checkSession: () => Promise<Session | null>;
@@ -16,6 +17,16 @@ interface SessionProviderProps {
 
 export function SessionProvider({ children }: SessionProviderProps) {
   const sessionManager = useSessionManager();
+  const initialized = useRef(false);
+
+  // 初回マウント時に一度だけ認証状態を初期化
+  useEffect(() => {
+    if (!initialized.current) {
+      initialized.current = true;
+      const { initialize } = useAuthStore.getState();
+      initialize();
+    }
+  }, []);
 
   return (
     <SessionContext.Provider value={sessionManager}>

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,5 +1,4 @@
 import { useAuthStore } from '@/stores/authStore';
-import { useEffect } from 'react';
 
 export function useAuth() {
   const {
@@ -9,14 +8,8 @@ export function useAuth() {
     error,
     signInWithGoogle,
     signOut,
-    initialize,
     clearError,
   } = useAuthStore();
-
-  // アプリ起動時の初期化
-  useEffect(() => {
-    initialize();
-  }, [initialize]);
 
   return {
     user,

--- a/src/hooks/useSessionManager.ts
+++ b/src/hooks/useSessionManager.ts
@@ -17,10 +17,6 @@ export function useSessionManager() {
       const { initialize, signOut } = useAuthStore.getState();
 
       switch (event) {
-        case "INITIAL_SESSION":
-          await initialize();
-          break;
-
         case "SIGNED_IN":
           await initialize();
           break;


### PR DESCRIPTION
- Remove useEffect from useAuth hook to prevent redundant initialize() calls
- Add one-time initialization in SessionProvider using useRef
- Remove INITIAL_SESSION handler from useSessionManager to avoid duplicate initialization
- This ensures initialize() is called only once on app mount and on actual auth state changes

## 概要
<!-- このPRで何を変更したかを簡潔に説明 -->

## 変更内容
<!-- 具体的な変更点をリストアップ -->
- 
- 
- 

## 動機・背景
<!-- なぜこの変更が必要だったかを説明 -->

## テスト
<!-- どのようなテストを行ったかを記載 -->
- [ ] ユニットテスト
- [ ] 統合テスト
- [ ] 手動テスト

## スクリーンショット
<!-- UI変更がある場合は画像を添付 -->

## チェックリスト
- [ ] pnpm lint:fixを行った
- [ ] CodeRabbitで問題がない
- [ ] `pnpm run build`で問題が出ない
- [ ] Vercel botで問題が出ない
- [ ] テストが通る
- [ ] ドキュメントを更新した（必要に応じて）