### PR TITLE
Fix authentication state not updating correctly

### DIFF
--- a/src/hooks/useSessionManager.ts
+++ b/src/hooks/useSessionManager.ts
@@ -35,6 +35,30 @@ export function useSessionManager() {
             break;
           }
 
+          // セッションが存在する場合、サーバー側にもセッションを確立
+          if (session) {
+            console.log(`[SessionManager] Syncing session to server for ${event}`);
+            try {
+              const response = await fetch('/api/auth/session', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                credentials: 'include',
+                body: JSON.stringify({
+                  access_token: session.access_token,
+                  refresh_token: session.refresh_token,
+                }),
+              });
+
+              if (!response.ok) {
+                console.error(`[SessionManager] Failed to sync session to server:`, response.status);
+              } else {
+                console.log(`[SessionManager] Session synced to server successfully`);
+              }
+            } catch (error) {
+              console.error(`[SessionManager] Error syncing session to server:`, error);
+            }
+          }
+
           console.log(`[SessionManager] Calling initialize for ${event}`);
           await initialize();
           break;


### PR DESCRIPTION
- Add explicit session token sync to server when SIGNED_IN event fires
- POST access_token and refresh_token to /api/auth/session endpoint
- Ensures server-side Supabase session is established before initialize()
- Fixes authentication state synchronization issue in production

## 概要
<!-- このPRで何を変更したかを簡潔に説明 -->

## 変更内容
<!-- 具体的な変更点をリストアップ -->
- 
- 
- 

## 動機・背景
<!-- なぜこの変更が必要だったかを説明 -->

## テスト
<!-- どのようなテストを行ったかを記載 -->
- [ ] ユニットテスト
- [ ] 統合テスト
- [ ] 手動テスト

## スクリーンショット
<!-- UI変更がある場合は画像を添付 -->

## チェックリスト
- [ ] pnpm lint:fixを行った
- [ ] CodeRabbitで問題がない
- [ ] `pnpm run build`で問題が出ない
- [ ] Vercel botで問題が出ない
- [ ] テストが通る
- [ ] ドキュメントを更新した（必要に応じて）