### PR TITLE
Remove unnecessary initialization failure notification

### DIFF
--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -352,18 +352,11 @@ export const useAuthStore = create<AuthStore>()(
           }
         } catch (error) {
           console.error("[AuthStore] Initialize error:", error);
-          const errorMessage =
-            error instanceof Error && error.message === "Request timeout"
-              ? "接続がタイムアウトしました。ネットワーク接続を確認してください。"
-              : error instanceof Error &&
-                error.message === "Supabase query timeout"
-              ? "データベース接続がタイムアウトしました。"
-              : "初期化に失敗しました。";
-
+          // 初期化エラーは内部的にログ出力するのみで、ユーザーには通知しない
           set({
             user: null,
             isAuthenticated: false,
-            error: errorMessage,
+            error: null,
             isLoading: false,
           });
         }


### PR DESCRIPTION
ログインが成功している場合でも初期化処理でエラーが発生すると
「初期化に失敗しました」という通知が表示されてしまう問題を修正。
初期化エラーは内部的にログ出力のみ行い、ユーザーには通知しないように変更。

## 概要
<!-- このPRで何を変更したかを簡潔に説明 -->

## 変更内容
<!-- 具体的な変更点をリストアップ -->
- 
- 
- 

## 動機・背景
<!-- なぜこの変更が必要だったかを説明 -->

## テスト
<!-- どのようなテストを行ったかを記載 -->
- [ ] ユニットテスト
- [ ] 統合テスト
- [ ] 手動テスト

## スクリーンショット
<!-- UI変更がある場合は画像を添付 -->

## チェックリスト
- [ ] pnpm lint:fixを行った
- [ ] CodeRabbitで問題がない
- [ ] `pnpm run build`で問題が出ない
- [ ] Vercel botで問題が出ない
- [ ] テストが通る
- [ ] ドキュメントを更新した（必要に応じて）