### PR TITLE
feat(layout): レスポンシブ基盤の追加 (#67 PR A)

### DIFF
--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -154,7 +154,7 @@ export default function HistoryPage() {
         )}
 
         {/* Stats */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mb-8">
           <div className="bg-white rounded-lg shadow-sm p-6">
             <p className="text-sm text-gray-600 mb-1">総振り返り数</p>
             <p className="text-3xl font-bold text-gray-900">{reflections.length}</p>
@@ -194,9 +194,9 @@ export default function HistoryPage() {
             </button>
           </div>
         ) : (
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {/* Calendar - Left side */}
-            <div className="lg:col-span-1">
+            <div className="md:col-span-1 lg:col-span-1">
               <Calendar
                 reflections={reflections}
                 frameworks={frameworks}
@@ -206,7 +206,7 @@ export default function HistoryPage() {
 
             {/* Reflection Detail Panel - Right side */}
             {selectedDetail && (
-              <div className="lg:col-span-2 bg-white rounded-lg shadow-sm overflow-hidden flex flex-col">
+              <div className="md:col-span-1 lg:col-span-2 bg-white rounded-lg shadow-sm overflow-hidden flex flex-col">
                 {/* Panel Header */}
                 <div className="sticky top-0 bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between flex-shrink-0">
                   <h2 className="text-xl font-bold text-gray-900">

--- a/src/components/layout/ResponsiveGrid.test.tsx
+++ b/src/components/layout/ResponsiveGrid.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import ResponsiveGrid from './ResponsiveGrid';
+
+describe('ResponsiveGrid', () => {
+  it('applies grid with the specified base columns and gap', () => {
+    const { container } = render(
+      <ResponsiveGrid cols={2} gap={6}>
+        <div>a</div>
+        <div>b</div>
+      </ResponsiveGrid>,
+    );
+
+    const grid = container.firstElementChild as HTMLElement;
+    expect(grid.className).toContain('grid');
+    expect(grid.className).toContain('grid-cols-2');
+    expect(grid.className).toContain('gap-6');
+  });
+
+  it('applies responsive column classes for each breakpoint', () => {
+    const { container } = render(
+      <ResponsiveGrid cols={1} smCols={2} mdCols={3} lgCols={4} xlCols={6}>
+        <div>a</div>
+      </ResponsiveGrid>,
+    );
+
+    const grid = container.firstElementChild as HTMLElement;
+    expect(grid.className).toContain('sm:grid-cols-2');
+    expect(grid.className).toContain('md:grid-cols-3');
+    expect(grid.className).toContain('lg:grid-cols-4');
+    expect(grid.className).toContain('xl:grid-cols-6');
+  });
+
+  it('renders children and custom element', () => {
+    const { container, getByText } = render(
+      <ResponsiveGrid cols={1} as="section">
+        <span>child</span>
+      </ResponsiveGrid>,
+    );
+
+    expect(container.firstElementChild?.tagName).toBe('SECTION');
+    expect(getByText('child')).toBeInTheDocument();
+  });
+});

--- a/src/components/layout/ResponsiveGrid.tsx
+++ b/src/components/layout/ResponsiveGrid.tsx
@@ -1,0 +1,99 @@
+import type { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+type ColCount = 1 | 2 | 3 | 4 | 5 | 6;
+type GapSize = 2 | 3 | 4 | 6 | 8;
+
+export interface ResponsiveGridProps {
+  children: ReactNode;
+  cols?: ColCount;
+  smCols?: ColCount;
+  mdCols?: ColCount;
+  lgCols?: ColCount;
+  xlCols?: ColCount;
+  gap?: GapSize;
+  className?: string;
+  as?: 'div' | 'section' | 'ul';
+}
+
+const baseColClasses: Record<ColCount, string> = {
+  1: 'grid-cols-1',
+  2: 'grid-cols-2',
+  3: 'grid-cols-3',
+  4: 'grid-cols-4',
+  5: 'grid-cols-5',
+  6: 'grid-cols-6',
+};
+
+const smColClasses: Record<ColCount, string> = {
+  1: 'sm:grid-cols-1',
+  2: 'sm:grid-cols-2',
+  3: 'sm:grid-cols-3',
+  4: 'sm:grid-cols-4',
+  5: 'sm:grid-cols-5',
+  6: 'sm:grid-cols-6',
+};
+
+const mdColClasses: Record<ColCount, string> = {
+  1: 'md:grid-cols-1',
+  2: 'md:grid-cols-2',
+  3: 'md:grid-cols-3',
+  4: 'md:grid-cols-4',
+  5: 'md:grid-cols-5',
+  6: 'md:grid-cols-6',
+};
+
+const lgColClasses: Record<ColCount, string> = {
+  1: 'lg:grid-cols-1',
+  2: 'lg:grid-cols-2',
+  3: 'lg:grid-cols-3',
+  4: 'lg:grid-cols-4',
+  5: 'lg:grid-cols-5',
+  6: 'lg:grid-cols-6',
+};
+
+const xlColClasses: Record<ColCount, string> = {
+  1: 'xl:grid-cols-1',
+  2: 'xl:grid-cols-2',
+  3: 'xl:grid-cols-3',
+  4: 'xl:grid-cols-4',
+  5: 'xl:grid-cols-5',
+  6: 'xl:grid-cols-6',
+};
+
+const gapClasses: Record<GapSize, string> = {
+  2: 'gap-2',
+  3: 'gap-3',
+  4: 'gap-4',
+  6: 'gap-6',
+  8: 'gap-8',
+};
+
+export default function ResponsiveGrid({
+  children,
+  cols = 1,
+  smCols,
+  mdCols,
+  lgCols,
+  xlCols,
+  gap = 4,
+  className,
+  as: Component = 'div',
+}: ResponsiveGridProps) {
+  return (
+    <Component
+      className={cn(
+        'grid',
+        baseColClasses[cols],
+        smCols && smColClasses[smCols],
+        mdCols && mdColClasses[mdCols],
+        lgCols && lgColClasses[lgCols],
+        xlCols && xlColClasses[xlCols],
+        gapClasses[gap],
+        className,
+      )}
+    >
+      {children}
+    </Component>
+  );
+}

--- a/src/components/layout/SidebarLayout.test.tsx
+++ b/src/components/layout/SidebarLayout.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import SidebarLayout from './SidebarLayout';
+
+describe('SidebarLayout', () => {
+  it('renders sidebar, main content, and optional right panel', () => {
+    render(
+      <SidebarLayout
+        sidebar={<div>sidebar-content</div>}
+        rightPanel={<div>right-panel</div>}
+      >
+        <div>main-content</div>
+      </SidebarLayout>,
+    );
+
+    expect(screen.getByText('sidebar-content')).toBeInTheDocument();
+    expect(screen.getByText('main-content')).toBeInTheDocument();
+    expect(screen.getByText('right-panel')).toBeInTheDocument();
+  });
+
+  it('omits right panel when not provided', () => {
+    const { container } = render(
+      <SidebarLayout sidebar={<div>sidebar</div>}>
+        <div>main</div>
+      </SidebarLayout>,
+    );
+
+    const asides = container.querySelectorAll('aside');
+    expect(asides).toHaveLength(1);
+  });
+
+  it('uses semantic main and aside landmarks', () => {
+    render(
+      <SidebarLayout sidebar={<div>s</div>}>
+        <div>m</div>
+      </SidebarLayout>,
+    );
+
+    expect(screen.getByRole('main')).toBeInTheDocument();
+    expect(screen.getByRole('complementary')).toBeInTheDocument();
+  });
+
+  it('applies the sidebarWidth variant', () => {
+    const { container } = render(
+      <SidebarLayout sidebar={<div>s</div>} sidebarWidth="lg">
+        <div>m</div>
+      </SidebarLayout>,
+    );
+
+    const aside = container.querySelector('aside');
+    expect(aside?.className).toContain('md:w-72');
+  });
+});

--- a/src/components/layout/SidebarLayout.test.tsx
+++ b/src/components/layout/SidebarLayout.test.tsx
@@ -50,4 +50,33 @@ describe('SidebarLayout', () => {
     const aside = container.querySelector('aside');
     expect(aside?.className).toContain('md:w-72');
   });
+
+  it('assigns distinct aria-labels to left and right asides', () => {
+    render(
+      <SidebarLayout
+        sidebar={<div>s</div>}
+        rightPanel={<div>r</div>}
+        sidebarAriaLabel="主要ナビゲーション"
+        rightPanelAriaLabel="詳細パネル"
+      >
+        <div>m</div>
+      </SidebarLayout>,
+    );
+
+    expect(screen.getByRole('complementary', { name: '主要ナビゲーション' })).toBeInTheDocument();
+    expect(screen.getByRole('complementary', { name: '詳細パネル' })).toBeInTheDocument();
+  });
+
+  it('right panel has a bounded md width to prevent overflow', () => {
+    const { container } = render(
+      <SidebarLayout sidebar={<div>s</div>} rightPanel={<div>r</div>}>
+        <div>m</div>
+      </SidebarLayout>,
+    );
+
+    const asides = container.querySelectorAll('aside');
+    const rightAside = asides[asides.length - 1];
+    expect(rightAside.className).toContain('md:w-64');
+    expect(rightAside.className).toContain('lg:w-80');
+  });
 });

--- a/src/components/layout/SidebarLayout.tsx
+++ b/src/components/layout/SidebarLayout.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+export interface SidebarLayoutProps {
+  sidebar: ReactNode;
+  children: ReactNode;
+  rightPanel?: ReactNode;
+  sidebarWidth?: 'sm' | 'md' | 'lg';
+  className?: string;
+  stickyBreakpoint?: 'md' | 'lg';
+}
+
+const sidebarWidthClasses: Record<NonNullable<SidebarLayoutProps['sidebarWidth']>, string> = {
+  sm: 'md:w-56 lg:w-60',
+  md: 'md:w-64 lg:w-72',
+  lg: 'md:w-72 lg:w-80',
+};
+
+const stickyTopClass = 'md:sticky md:top-20';
+
+export default function SidebarLayout({
+  sidebar,
+  children,
+  rightPanel,
+  sidebarWidth = 'md',
+  className,
+  stickyBreakpoint = 'md',
+}: SidebarLayoutProps) {
+  const stickyClass =
+    stickyBreakpoint === 'md' ? stickyTopClass : 'lg:sticky lg:top-20';
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col md:flex-row gap-6 w-full',
+        className,
+      )}
+    >
+      <aside
+        className={cn(
+          'w-full shrink-0',
+          sidebarWidthClasses[sidebarWidth],
+          stickyClass,
+          'md:self-start',
+        )}
+      >
+        {sidebar}
+      </aside>
+      <main className="flex-1 min-w-0">{children}</main>
+      {rightPanel && (
+        <aside className="w-full lg:w-80 shrink-0 lg:self-start lg:sticky lg:top-20">
+          {rightPanel}
+        </aside>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/SidebarLayout.tsx
+++ b/src/components/layout/SidebarLayout.tsx
@@ -8,6 +8,8 @@ export interface SidebarLayoutProps {
   sidebarWidth?: 'sm' | 'md' | 'lg';
   className?: string;
   stickyBreakpoint?: 'md' | 'lg';
+  sidebarAriaLabel?: string;
+  rightPanelAriaLabel?: string;
 }
 
 const sidebarWidthClasses: Record<NonNullable<SidebarLayoutProps['sidebarWidth']>, string> = {
@@ -25,6 +27,8 @@ export default function SidebarLayout({
   sidebarWidth = 'md',
   className,
   stickyBreakpoint = 'md',
+  sidebarAriaLabel = 'サイドバー',
+  rightPanelAriaLabel = '関連情報パネル',
 }: SidebarLayoutProps) {
   const stickyClass =
     stickyBreakpoint === 'md' ? stickyTopClass : 'lg:sticky lg:top-20';
@@ -37,6 +41,7 @@ export default function SidebarLayout({
       )}
     >
       <aside
+        aria-label={sidebarAriaLabel}
         className={cn(
           'w-full shrink-0',
           sidebarWidthClasses[sidebarWidth],
@@ -48,7 +53,10 @@ export default function SidebarLayout({
       </aside>
       <main className="flex-1 min-w-0">{children}</main>
       {rightPanel && (
-        <aside className="w-full lg:w-80 shrink-0 lg:self-start lg:sticky lg:top-20">
+        <aside
+          aria-label={rightPanelAriaLabel}
+          className="w-full md:w-64 lg:w-80 shrink-0 lg:self-start lg:sticky lg:top-20"
+        >
           {rightPanel}
         </aside>
       )}

--- a/src/hooks/useMediaQuery.test.ts
+++ b/src/hooks/useMediaQuery.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { useMediaQuery, useBreakpoint, useIsMobile, useIsDesktop } from './useMediaQuery';
+import { useMediaQuery, useBreakpoint, useIsMobile, useIsTablet, useIsDesktop } from './useMediaQuery';
 
 type Listener = (event: MediaQueryListEvent) => void;
 
@@ -103,5 +103,25 @@ describe('useBreakpoint helpers', () => {
 
     const { result } = renderHook(() => useIsDesktop());
     expect(result.current).toBe(true);
+  });
+
+  it('useIsTablet is true when md matches but lg does not', () => {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => {
+      if (query === '(min-width: 768px)') return createMock(true);
+      if (query === '(min-width: 1024px)') return createMock(false);
+      return createMock(false);
+    }) as unknown as typeof window.matchMedia;
+
+    const { result } = renderHook(() => useIsTablet());
+    expect(result.current).toBe(true);
+  });
+
+  it('useIsTablet is false when both md and lg match (desktop)', () => {
+    window.matchMedia = vi
+      .fn()
+      .mockImplementation(() => createMock(true)) as unknown as typeof window.matchMedia;
+
+    const { result } = renderHook(() => useIsTablet());
+    expect(result.current).toBe(false);
   });
 });

--- a/src/hooks/useMediaQuery.test.ts
+++ b/src/hooks/useMediaQuery.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useMediaQuery, useBreakpoint, useIsMobile, useIsDesktop } from './useMediaQuery';
+
+type Listener = (event: MediaQueryListEvent) => void;
+
+interface MockMediaQueryList {
+  matches: boolean;
+  media: string;
+  addEventListener: (type: 'change', cb: Listener) => void;
+  removeEventListener: (type: 'change', cb: Listener) => void;
+  dispatch: (matches: boolean) => void;
+}
+
+const createMock = (initial: boolean): MockMediaQueryList => {
+  const listeners = new Set<Listener>();
+  return {
+    matches: initial,
+    media: '',
+    addEventListener: (_type, cb) => listeners.add(cb),
+    removeEventListener: (_type, cb) => listeners.delete(cb),
+    dispatch(matches: boolean) {
+      this.matches = matches;
+      listeners.forEach((cb) =>
+        cb({ matches, media: this.media } as MediaQueryListEvent),
+      );
+    },
+  };
+};
+
+describe('useMediaQuery', () => {
+  const originalMatchMedia = window.matchMedia;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it('returns current match state', () => {
+    const mock = createMock(true);
+    window.matchMedia = vi.fn().mockReturnValue(mock) as unknown as typeof window.matchMedia;
+
+    const { result } = renderHook(() => useMediaQuery('(min-width: 768px)'));
+    expect(result.current).toBe(true);
+  });
+
+  it('updates when media query state changes', () => {
+    const mock = createMock(false);
+    window.matchMedia = vi.fn().mockReturnValue(mock) as unknown as typeof window.matchMedia;
+
+    const { result } = renderHook(() => useMediaQuery('(min-width: 768px)'));
+    expect(result.current).toBe(false);
+
+    act(() => mock.dispatch(true));
+    expect(result.current).toBe(true);
+  });
+
+  it('unsubscribes the listener on unmount', () => {
+    const mock = createMock(false);
+    const removeSpy = vi.spyOn(mock, 'removeEventListener');
+    window.matchMedia = vi.fn().mockReturnValue(mock) as unknown as typeof window.matchMedia;
+
+    const { unmount } = renderHook(() => useMediaQuery('(min-width: 768px)'));
+    unmount();
+    expect(removeSpy).toHaveBeenCalledWith('change', expect.any(Function));
+  });
+});
+
+describe('useBreakpoint helpers', () => {
+  const originalMatchMedia = window.matchMedia;
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+    vi.restoreAllMocks();
+  });
+
+  it('useBreakpoint uses min-width query for named breakpoint', () => {
+    const mock = createMock(true);
+    const spy = vi.fn().mockReturnValue(mock);
+    window.matchMedia = spy as unknown as typeof window.matchMedia;
+
+    const { result } = renderHook(() => useBreakpoint('md'));
+    expect(spy).toHaveBeenCalledWith('(min-width: 768px)');
+    expect(result.current).toBe(true);
+  });
+
+  it('useIsMobile is the inverse of md breakpoint', () => {
+    window.matchMedia = vi
+      .fn()
+      .mockReturnValue(createMock(false)) as unknown as typeof window.matchMedia;
+
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(true);
+  });
+
+  it('useIsDesktop is true when lg matches', () => {
+    window.matchMedia = vi
+      .fn()
+      .mockImplementation(() => createMock(true)) as unknown as typeof window.matchMedia;
+
+    const { result } = renderHook(() => useIsDesktop());
+    expect(result.current).toBe(true);
+  });
+});

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,49 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export const BREAKPOINTS = {
+  sm: 640,
+  md: 768,
+  lg: 1024,
+  xl: 1280,
+  '2xl': 1536,
+} as const;
+
+export type Breakpoint = keyof typeof BREAKPOINTS;
+
+const buildMinWidthQuery = (px: number): string => `(min-width: ${px}px)`;
+
+export const useMediaQuery = (query: string): boolean => {
+  const [matches, setMatches] = useState<boolean>(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return false;
+    }
+    return window.matchMedia(query).matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
+    const mql = window.matchMedia(query);
+    const handler = (event: MediaQueryListEvent) => setMatches(event.matches);
+    setMatches(mql.matches);
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, [query]);
+
+  return matches;
+};
+
+export const useBreakpoint = (breakpoint: Breakpoint): boolean => {
+  return useMediaQuery(buildMinWidthQuery(BREAKPOINTS[breakpoint]));
+};
+
+export const useIsMobile = (): boolean => !useBreakpoint('md');
+export const useIsTablet = (): boolean => {
+  const isMdUp = useBreakpoint('md');
+  const isLgUp = useBreakpoint('lg');
+  return isMdUp && !isLgUp;
+};
+export const useIsDesktop = (): boolean => useBreakpoint('lg');

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,9 +1,26 @@
 import '@testing-library/jest-dom';
-import { expect, afterEach } from 'vitest';
+import { expect, afterEach, vi } from 'vitest';
 import { cleanup } from '@testing-library/react';
 import * as matchers from '@testing-library/jest-dom/matchers';
 
 expect.extend(matchers);
+
+if (typeof window !== 'undefined' && !window.matchMedia) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
 
 afterEach(() => {
   cleanup();


### PR DESCRIPTION
## Summary
Phase 2.3 (Issue #67) の UI/UX 改善を 3 つの PR に分割して進めている最初の PR です。レスポンシブ基盤を整備します。

- `useMediaQuery` / `useBreakpoint` / `useIsMobile` / `useIsTablet` / `useIsDesktop` フックを追加 (SSR セーフ、change イベントリスナーの自動クリーンアップ付き)
- `ResponsiveGrid` コンポーネント: sm/md/lg/xl それぞれの列数と gap を宣言的に指定可能
- `SidebarLayout` コンポーネント: sidebar + main + オプションの rightPanel を semantic な `<main>` / `<aside>` でレイアウト
- 履歴ページ: 統計カードを `sm:grid-cols-2`、カレンダー + 詳細ペインをタブレット 2 列表示に対応
- テストセットアップに `matchMedia` のデフォルトモックを追加

## 分割計画
- **PR A (本 PR)**: レスポンシブ基盤 (`useMediaQuery`, `ResponsiveGrid`, `SidebarLayout`、既存ページのタブレット対応)
- PR B: アニメーション & ローディング (`FadeIn`, `SlideIn`, `SkeletonLoader`, 統一 `Loading.tsx`)
- PR C: アクセシビリティ & タイポグラフィ (WCAG 2.1 AA、ARIA、フォーカス管理、日本語フォント最適化)

## Test plan
- [x] `pnpm vitest run src/hooks/useMediaQuery.test.ts src/components/layout` → 13 件グリーン
- [x] `pnpm vitest run` 全体 → authStore の既存失敗 1 件以外 293 件グリーン
- [ ] タブレット実機 (768–1023px) で履歴ページの 2 カラムレイアウトを目視確認
- [ ] デスクトップ (>=1024px) で従来の 3 カラムレイアウトが維持されているか確認
- [ ] モバイル (<768px) で 1 カラムへ崩れるか確認

Refs #67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New responsive layout components and a flexible grid/sidebars for improved UI across breakpoints
  * Media query hooks for dynamic responsive behavior
  * History page now uses 2-column layouts at earlier breakpoints for better small-screen usability

* **Tests**
  * Added comprehensive tests for layout components, responsive grid, sidebar behavior, and media-query hooks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->