### PR TITLE
feat(ui): アニメーション・ローディングコンポーネント追加 (Issue #67 PR B)

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -7,6 +7,8 @@ import { useEffect } from 'react';
 import { PlusCircle, Calendar, BarChart3, Settings } from 'lucide-react';
 import DashboardLoading from './loading';
 import Header from '@/components/layout/Header';
+import { FadeIn } from '@/components/animations/FadeIn';
+import { SlideIn } from '@/components/animations/SlideIn';
 
 export default function DashboardPage() {
   const { user, signOut, isLoading, error } = useAuth();
@@ -69,17 +71,22 @@ export default function DashboardPage() {
       {/* Main Content */}
       <main className="max-w-6xl mx-auto px-4 py-8">
         {/* Welcome Message */}
-        <div className="mb-8">
+        <FadeIn className="mb-8" duration={400}>
           <h2 className="text-xl font-semibold text-gray-900 mb-2">
             振り返りを始めましょう
           </h2>
           <p className="text-gray-600">
             3分で今週の振り返りを記録し、継続的な成長を実現しましょう。
           </p>
-        </div>
+        </FadeIn>
 
         {/* Quick Actions */}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
+        <SlideIn
+          direction="bottom"
+          delay={100}
+          duration={400}
+          className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8"
+        >
           {/* 新しい振り返り */}
           <Link href="/reflection">
             <Card className="cursor-pointer hover:shadow-md transition-shadow h-full">
@@ -126,9 +133,10 @@ export default function DashboardPage() {
               </CardContent>
             </Card>
           </Link>
-        </div>
+        </SlideIn>
 
         {/* Getting Started */}
+        <FadeIn delay={200} duration={500}>
         <Card>
           <CardHeader>
             <CardTitle>はじめに</CardTitle>
@@ -173,6 +181,7 @@ export default function DashboardPage() {
             </div>
           </CardContent>
         </Card>
+        </FadeIn>
       </main>
     </div>
   );

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -10,8 +10,8 @@ import { reflectionService } from '@/services/reflectionService';
 import type { Reflection } from '@/types/reflection';
 import type { Framework } from '@/types/framework';
 import { X, ChevronRight } from 'lucide-react';
-import { format, parseISO } from 'date-fns';
-import { ja } from 'date-fns/locale';
+import { FadeIn } from '@/components/animations/FadeIn';
+import { SlideIn } from '@/components/animations/SlideIn';
 
 interface ReflectionDetail {
   date: Date;
@@ -154,7 +154,11 @@ export default function HistoryPage() {
         )}
 
         {/* Stats */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
+        <SlideIn
+          direction="bottom"
+          duration={400}
+          className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8"
+        >
           <div className="bg-white rounded-lg shadow-sm p-6">
             <p className="text-sm text-gray-600 mb-1">総振り返り数</p>
             <p className="text-3xl font-bold text-gray-900">{reflections.length}</p>
@@ -180,21 +184,23 @@ export default function HistoryPage() {
               {new Set(reflections.map((r) => r.reflection_date)).size}
             </p>
           </div>
-        </div>
+        </SlideIn>
 
         {/* Calendar and Detail View - Side by side */}
         {reflections.length === 0 ? (
-          <div className="bg-white rounded-lg shadow-sm p-12 text-center">
-            <p className="text-gray-600 mb-4">まだ振り返りがありません</p>
-            <button
-              onClick={() => router.push('/reflection')}
-              className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
-            >
-              最初の振り返りを作成
-            </button>
-          </div>
+          <FadeIn duration={400}>
+            <div className="bg-white rounded-lg shadow-sm p-12 text-center">
+              <p className="text-gray-600 mb-4">まだ振り返りがありません</p>
+              <button
+                onClick={() => router.push('/reflection')}
+                className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+              >
+                最初の振り返りを作成
+              </button>
+            </div>
+          </FadeIn>
         ) : (
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <FadeIn delay={100} duration={400} className="grid grid-cols-1 lg:grid-cols-3 gap-6">
             {/* Calendar - Left side */}
             <div className="lg:col-span-1">
               <Calendar
@@ -206,7 +212,12 @@ export default function HistoryPage() {
 
             {/* Reflection Detail Panel - Right side */}
             {selectedDetail && (
-              <div className="lg:col-span-2 bg-white rounded-lg shadow-sm overflow-hidden flex flex-col">
+              <SlideIn
+                key={selectedDetail.date.toISOString()}
+                direction="right"
+                duration={300}
+                className="lg:col-span-2 bg-white rounded-lg shadow-sm overflow-hidden flex flex-col"
+              >
                 {/* Panel Header */}
                 <div className="sticky top-0 bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between flex-shrink-0">
                   <h2 className="text-xl font-bold text-gray-900">
@@ -302,9 +313,9 @@ export default function HistoryPage() {
                     );
                   })}
                 </div>
-              </div>
+              </SlideIn>
             )}
-          </div>
+          </FadeIn>
         )}
       </main>
     </div>

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -213,7 +213,11 @@ export default function HistoryPage() {
             {/* Reflection Detail Panel - Right side */}
             {selectedDetail && (
               <SlideIn
-                key={selectedDetail.date.toISOString()}
+                key={
+                  selectedDetail.date instanceof Date && !isNaN(selectedDetail.date.getTime())
+                    ? String(selectedDetail.date.getTime())
+                    : 'detail'
+                }
                 direction="right"
                 duration={300}
                 className="lg:col-span-2 bg-white rounded-lg shadow-sm overflow-hidden flex flex-col"

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -6,6 +6,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { ProfileCard } from '@/components/profile/ProfileCard';
 import Header from '@/components/layout/Header';
 import DashboardLoading from '../dashboard/loading';
+import { FadeIn } from '@/components/animations/FadeIn';
 
 export default function ProfilePage() {
   const { user, signOut, isLoading, error } = useAuth();
@@ -97,11 +98,13 @@ export default function ProfilePage() {
           </div>
         )}
 
-        <ProfileCard
-          user={user}
-          onUpdateProfile={handleUpdateProfile}
-          isUpdating={isUpdating}
-        />
+        <FadeIn duration={400}>
+          <ProfileCard
+            user={user}
+            onUpdateProfile={handleUpdateProfile}
+            isUpdating={isUpdating}
+          />
+        </FadeIn>
       </main>
     </div>
   );

--- a/src/components/animations/FadeIn.test.tsx
+++ b/src/components/animations/FadeIn.test.tsx
@@ -2,9 +2,23 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, act } from '@testing-library/react';
 import { FadeIn } from './FadeIn';
 
+const mockMatchMedia = (matches: boolean) => {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })) as unknown as typeof window.matchMedia;
+};
+
 describe('FadeIn', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    mockMatchMedia(false);
   });
 
   afterEach(() => {
@@ -77,5 +91,18 @@ describe('FadeIn', () => {
     );
     const wrapper = screen.getByTestId('child').parentElement!;
     expect(wrapper.className).toContain('motion-reduce:transition-none');
+    expect(wrapper.className).toContain('motion-reduce:opacity-100');
+  });
+
+  it('renders content visible immediately when prefers-reduced-motion is set', () => {
+    mockMatchMedia(true);
+    render(
+      <FadeIn delay={500}>
+        <span data-testid="child">child</span>
+      </FadeIn>,
+    );
+    const wrapper = screen.getByTestId('child').parentElement!;
+    expect(wrapper.className).toContain('opacity-100');
+    expect(wrapper.className).not.toContain('opacity-0');
   });
 });

--- a/src/components/animations/FadeIn.test.tsx
+++ b/src/components/animations/FadeIn.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { FadeIn } from './FadeIn';
+
+describe('FadeIn', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders children', () => {
+    render(<FadeIn>hello</FadeIn>);
+    expect(screen.getByText('hello')).toBeInTheDocument();
+  });
+
+  it('starts fully transparent and becomes visible after mount', () => {
+    render(
+      <FadeIn>
+        <span data-testid="child">child</span>
+      </FadeIn>,
+    );
+    const wrapper = screen.getByTestId('child').parentElement!;
+    expect(wrapper.className).toContain('opacity-0');
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    expect(wrapper.className).toContain('opacity-100');
+  });
+
+  it('respects the delay prop before becoming visible', () => {
+    render(
+      <FadeIn delay={500}>
+        <span data-testid="child">child</span>
+      </FadeIn>,
+    );
+    const wrapper = screen.getByTestId('child').parentElement!;
+    expect(wrapper.className).toContain('opacity-0');
+    act(() => {
+      vi.advanceTimersByTime(499);
+    });
+    expect(wrapper.className).toContain('opacity-0');
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(wrapper.className).toContain('opacity-100');
+  });
+
+  it('applies custom duration via inline style', () => {
+    render(
+      <FadeIn duration={750}>
+        <span data-testid="child">child</span>
+      </FadeIn>,
+    );
+    const wrapper = screen.getByTestId('child').parentElement!;
+    expect(wrapper.style.transitionDuration).toBe('750ms');
+  });
+
+  it('renders as the supplied element when "as" is provided', () => {
+    render(
+      <FadeIn as="section" className="my-cls">
+        <span data-testid="child">child</span>
+      </FadeIn>,
+    );
+    const wrapper = screen.getByTestId('child').parentElement!;
+    expect(wrapper.tagName).toBe('SECTION');
+    expect(wrapper.className).toContain('my-cls');
+  });
+
+  it('includes motion-reduce class for prefers-reduced-motion', () => {
+    render(
+      <FadeIn>
+        <span data-testid="child">child</span>
+      </FadeIn>,
+    );
+    const wrapper = screen.getByTestId('child').parentElement!;
+    expect(wrapper.className).toContain('motion-reduce:transition-none');
+  });
+});

--- a/src/components/animations/FadeIn.test.tsx
+++ b/src/components/animations/FadeIn.test.tsx
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, act } from '@testing-library/react';
 import { FadeIn } from './FadeIn';
 
+const originalMatchMedia = window.matchMedia;
+
 const mockMatchMedia = (matches: boolean) => {
   window.matchMedia = vi.fn().mockImplementation((query: string) => ({
     matches,
@@ -22,7 +24,10 @@ describe('FadeIn', () => {
   });
 
   afterEach(() => {
+    vi.runOnlyPendingTimers();
     vi.useRealTimers();
+    window.matchMedia = originalMatchMedia;
+    vi.restoreAllMocks();
   });
 
   it('renders children', () => {

--- a/src/components/animations/FadeIn.tsx
+++ b/src/components/animations/FadeIn.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect, useState, type ReactNode, type ElementType } from 'react';
+import { cn } from '@/lib/utils';
+
+export interface FadeInProps {
+  children: ReactNode;
+  duration?: number;
+  delay?: number;
+  className?: string;
+  as?: ElementType;
+}
+
+export function FadeIn({
+  children,
+  duration = 300,
+  delay = 0,
+  className,
+  as: Component = 'div',
+}: FadeInProps) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setVisible(true), Math.max(0, delay));
+    return () => window.clearTimeout(timer);
+  }, [delay]);
+
+  return (
+    <Component
+      className={cn(
+        'transition-opacity ease-out motion-reduce:transition-none',
+        visible ? 'opacity-100' : 'opacity-0',
+        className,
+      )}
+      style={{ transitionDuration: `${duration}ms` }}
+    >
+      {children}
+    </Component>
+  );
+}
+
+export default FadeIn;

--- a/src/components/animations/FadeIn.tsx
+++ b/src/components/animations/FadeIn.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, type ReactNode, type ElementType } from 'react';
 import { cn } from '@/lib/utils';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
 
 export interface FadeInProps {
   children: ReactNode;
@@ -18,17 +19,22 @@ export function FadeIn({
   className,
   as: Component = 'div',
 }: FadeInProps) {
-  const [visible, setVisible] = useState(false);
+  const prefersReducedMotion = useReducedMotion();
+  const [visible, setVisible] = useState<boolean>(() => prefersReducedMotion);
 
   useEffect(() => {
+    if (prefersReducedMotion) {
+      setVisible(true);
+      return;
+    }
     const timer = window.setTimeout(() => setVisible(true), Math.max(0, delay));
     return () => window.clearTimeout(timer);
-  }, [delay]);
+  }, [delay, prefersReducedMotion]);
 
   return (
     <Component
       className={cn(
-        'transition-opacity ease-out motion-reduce:transition-none',
+        'transition-opacity ease-out motion-reduce:transition-none motion-reduce:opacity-100',
         visible ? 'opacity-100' : 'opacity-0',
         className,
       )}

--- a/src/components/animations/SlideIn.test.tsx
+++ b/src/components/animations/SlideIn.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { SlideIn } from './SlideIn';
+
+describe('SlideIn', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders children', () => {
+    render(<SlideIn>hello</SlideIn>);
+    expect(screen.getByText('hello')).toBeInTheDocument();
+  });
+
+  it('starts off-screen and animates to translate(0,0)', () => {
+    render(
+      <SlideIn direction="bottom" distance={20}>
+        <span data-testid="child">child</span>
+      </SlideIn>,
+    );
+    const wrapper = screen.getByTestId('child').parentElement!;
+    expect(wrapper.style.transform).toBe('translate3d(0, 20px, 0)');
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    expect(wrapper.style.transform).toBe('translate3d(0, 0, 0)');
+  });
+
+  it.each([
+    ['top', 'translate3d(0, -16px, 0)'],
+    ['bottom', 'translate3d(0, 16px, 0)'],
+    ['left', 'translate3d(-16px, 0, 0)'],
+    ['right', 'translate3d(16px, 0, 0)'],
+  ] as const)('uses correct initial offset for direction "%s"', (direction, expected) => {
+    render(
+      <SlideIn direction={direction}>
+        <span data-testid="child">child</span>
+      </SlideIn>,
+    );
+    const wrapper = screen.getByTestId('child').parentElement!;
+    expect(wrapper.style.transform).toBe(expected);
+  });
+
+  it('honours the delay prop', () => {
+    render(
+      <SlideIn delay={300} direction="left">
+        <span data-testid="child">child</span>
+      </SlideIn>,
+    );
+    const wrapper = screen.getByTestId('child').parentElement!;
+    expect(wrapper.style.transform).toBe('translate3d(-16px, 0, 0)');
+    act(() => {
+      vi.advanceTimersByTime(299);
+    });
+    expect(wrapper.style.transform).toBe('translate3d(-16px, 0, 0)');
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(wrapper.style.transform).toBe('translate3d(0, 0, 0)');
+  });
+
+  it('applies motion-reduce classes', () => {
+    render(
+      <SlideIn>
+        <span data-testid="child">child</span>
+      </SlideIn>,
+    );
+    const wrapper = screen.getByTestId('child').parentElement!;
+    expect(wrapper.className).toContain('motion-reduce:transition-none');
+    expect(wrapper.className).toContain('motion-reduce:transform-none');
+  });
+});

--- a/src/components/animations/SlideIn.test.tsx
+++ b/src/components/animations/SlideIn.test.tsx
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, act } from '@testing-library/react';
 import { SlideIn } from './SlideIn';
 
+const originalMatchMedia = window.matchMedia;
+
 const mockMatchMedia = (matches: boolean) => {
   window.matchMedia = vi.fn().mockImplementation((query: string) => ({
     matches,
@@ -22,7 +24,10 @@ describe('SlideIn', () => {
   });
 
   afterEach(() => {
+    vi.runOnlyPendingTimers();
     vi.useRealTimers();
+    window.matchMedia = originalMatchMedia;
+    vi.restoreAllMocks();
   });
 
   it('renders children', () => {

--- a/src/components/animations/SlideIn.test.tsx
+++ b/src/components/animations/SlideIn.test.tsx
@@ -2,9 +2,23 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, act } from '@testing-library/react';
 import { SlideIn } from './SlideIn';
 
+const mockMatchMedia = (matches: boolean) => {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })) as unknown as typeof window.matchMedia;
+};
+
 describe('SlideIn', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    mockMatchMedia(false);
   });
 
   afterEach(() => {
@@ -63,7 +77,7 @@ describe('SlideIn', () => {
     expect(wrapper.style.transform).toBe('translate3d(0, 0, 0)');
   });
 
-  it('applies motion-reduce classes', () => {
+  it('applies motion-reduce class fallbacks for opacity/transition', () => {
     render(
       <SlideIn>
         <span data-testid="child">child</span>
@@ -71,6 +85,18 @@ describe('SlideIn', () => {
     );
     const wrapper = screen.getByTestId('child').parentElement!;
     expect(wrapper.className).toContain('motion-reduce:transition-none');
-    expect(wrapper.className).toContain('motion-reduce:transform-none');
+    expect(wrapper.className).toContain('motion-reduce:opacity-100');
+  });
+
+  it('skips animation entirely when prefers-reduced-motion is set', () => {
+    mockMatchMedia(true);
+    render(
+      <SlideIn direction="bottom" distance={24}>
+        <span data-testid="child">child</span>
+      </SlideIn>,
+    );
+    const wrapper = screen.getByTestId('child').parentElement!;
+    expect(wrapper.className).toContain('opacity-100');
+    expect(wrapper.style.transform).toBe('');
   });
 });

--- a/src/components/animations/SlideIn.tsx
+++ b/src/components/animations/SlideIn.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect, useState, type ReactNode, type ElementType } from 'react';
+import { useEffect, useState, type ReactNode, type ElementType, type CSSProperties } from 'react';
 import { cn } from '@/lib/utils';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
 
 export type SlideDirection = 'top' | 'bottom' | 'left' | 'right';
 
@@ -37,24 +38,33 @@ export function SlideIn({
   className,
   as: Component = 'div',
 }: SlideInProps) {
-  const [visible, setVisible] = useState(false);
+  const prefersReducedMotion = useReducedMotion();
+  const [visible, setVisible] = useState<boolean>(() => prefersReducedMotion);
 
   useEffect(() => {
+    if (prefersReducedMotion) {
+      setVisible(true);
+      return;
+    }
     const timer = window.setTimeout(() => setVisible(true), Math.max(0, delay));
     return () => window.clearTimeout(timer);
-  }, [delay]);
+  }, [delay, prefersReducedMotion]);
+
+  const style: CSSProperties = prefersReducedMotion
+    ? { transitionDuration: '0ms' }
+    : {
+        transitionDuration: `${duration}ms`,
+        transform: visible ? 'translate3d(0, 0, 0)' : getOffset(direction, distance),
+      };
 
   return (
     <Component
       className={cn(
-        'transition-all ease-out motion-reduce:transition-none motion-reduce:transform-none',
+        'transition-all ease-out motion-reduce:transition-none motion-reduce:opacity-100',
         visible ? 'opacity-100' : 'opacity-0',
         className,
       )}
-      style={{
-        transitionDuration: `${duration}ms`,
-        transform: visible ? 'translate3d(0, 0, 0)' : getOffset(direction, distance),
-      }}
+      style={style}
     >
       {children}
     </Component>

--- a/src/components/animations/SlideIn.tsx
+++ b/src/components/animations/SlideIn.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useEffect, useState, type ReactNode, type ElementType } from 'react';
+import { cn } from '@/lib/utils';
+
+export type SlideDirection = 'top' | 'bottom' | 'left' | 'right';
+
+export interface SlideInProps {
+  children: ReactNode;
+  direction?: SlideDirection;
+  duration?: number;
+  delay?: number;
+  distance?: number;
+  className?: string;
+  as?: ElementType;
+}
+
+const getOffset = (direction: SlideDirection, distance: number): string => {
+  switch (direction) {
+    case 'top':
+      return `translate3d(0, -${distance}px, 0)`;
+    case 'bottom':
+      return `translate3d(0, ${distance}px, 0)`;
+    case 'left':
+      return `translate3d(-${distance}px, 0, 0)`;
+    case 'right':
+      return `translate3d(${distance}px, 0, 0)`;
+  }
+};
+
+export function SlideIn({
+  children,
+  direction = 'bottom',
+  duration = 400,
+  delay = 0,
+  distance = 16,
+  className,
+  as: Component = 'div',
+}: SlideInProps) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setVisible(true), Math.max(0, delay));
+    return () => window.clearTimeout(timer);
+  }, [delay]);
+
+  return (
+    <Component
+      className={cn(
+        'transition-all ease-out motion-reduce:transition-none motion-reduce:transform-none',
+        visible ? 'opacity-100' : 'opacity-0',
+        className,
+      )}
+      style={{
+        transitionDuration: `${duration}ms`,
+        transform: visible ? 'translate3d(0, 0, 0)' : getOffset(direction, distance),
+      }}
+    >
+      {children}
+    </Component>
+  );
+}
+
+export default SlideIn;

--- a/src/components/feedback/Loading.test.tsx
+++ b/src/components/feedback/Loading.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Loading } from './Loading';
+
+describe('Loading', () => {
+  it('renders a status region with default sr-only label', () => {
+    render(<Loading />);
+    const status = screen.getByRole('status');
+    expect(status).toHaveAttribute('aria-busy', 'true');
+    expect(status).toHaveAttribute('aria-live', 'polite');
+    expect(screen.getByText('読み込み中')).toBeInTheDocument();
+  });
+
+  it('renders the supplied message', () => {
+    render(<Loading message="データを取得中..." />);
+    expect(screen.getByText('データを取得中...')).toBeInTheDocument();
+  });
+
+  it('applies the spinner size class for large variant', () => {
+    const { container } = render(<Loading size="lg" />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('class')).toContain('w-10');
+    expect(svg?.getAttribute('class')).toContain('h-10');
+  });
+
+  it('renders a fixed full-screen overlay when fullScreen is true', () => {
+    const { container } = render(<Loading fullScreen message="読み込み" />);
+    const overlay = container.querySelector('div.fixed.inset-0');
+    expect(overlay).toBeInTheDocument();
+  });
+
+  it('honours motion-reduce on the spinner', () => {
+    const { container } = render(<Loading />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('class')).toContain('motion-reduce:animate-none');
+  });
+});

--- a/src/components/feedback/Loading.tsx
+++ b/src/components/feedback/Loading.tsx
@@ -1,0 +1,64 @@
+import { Loader2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export type LoadingSize = 'sm' | 'md' | 'lg';
+
+export interface LoadingProps {
+  message?: string;
+  size?: LoadingSize;
+  fullScreen?: boolean;
+  className?: string;
+}
+
+const sizeClass: Record<LoadingSize, string> = {
+  sm: 'w-4 h-4',
+  md: 'w-6 h-6',
+  lg: 'w-10 h-10',
+};
+
+const textSizeClass: Record<LoadingSize, string> = {
+  sm: 'text-xs',
+  md: 'text-sm',
+  lg: 'text-base',
+};
+
+export function Loading({
+  message,
+  size = 'md',
+  fullScreen = false,
+  className,
+}: LoadingProps) {
+  const content = (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      className={cn(
+        'flex flex-col items-center justify-center gap-2 text-gray-600',
+        className,
+      )}
+    >
+      <Loader2
+        aria-hidden="true"
+        className={cn('animate-spin motion-reduce:animate-none text-gray-500', sizeClass[size])}
+      />
+      {message ? (
+        <p className={cn('text-gray-600', textSizeClass[size])}>{message}</p>
+      ) : (
+        <span className="sr-only">読み込み中</span>
+      )}
+    </div>
+  );
+
+  if (fullScreen) {
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-white/80 backdrop-blur-sm">
+        {content}
+      </div>
+    );
+  }
+
+  return content;
+}
+
+export default Loading;

--- a/src/components/feedback/SkeletonLoader.test.tsx
+++ b/src/components/feedback/SkeletonLoader.test.tsx
@@ -43,6 +43,22 @@ describe('SkeletonLoader', () => {
     expect(wrapper.className).toContain('animate-pulse');
   });
 
+  it('treats Infinity count as a single skeleton without throwing', () => {
+    expect(() =>
+      render(<SkeletonLoader count={Number.POSITIVE_INFINITY} />),
+    ).not.toThrow();
+    const wrapper = screen.getByRole('status');
+    expect(wrapper.className).toContain('animate-pulse');
+  });
+
+  it('caps very large count values to avoid runaway rendering', () => {
+    render(<SkeletonLoader count={9999} />);
+    const wrapper = screen.getByRole('status');
+    const lines = wrapper.querySelectorAll('[aria-hidden="true"]');
+    expect(lines.length).toBeLessThanOrEqual(50);
+    expect(lines.length).toBeGreaterThan(0);
+  });
+
   it('includes motion-reduce class for reduced-motion users', () => {
     render(<SkeletonLoader />);
     const node = screen.getByRole('status');

--- a/src/components/feedback/SkeletonLoader.test.tsx
+++ b/src/components/feedback/SkeletonLoader.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SkeletonLoader } from './SkeletonLoader';
+
+describe('SkeletonLoader', () => {
+  it('renders a single skeleton with status role', () => {
+    render(<SkeletonLoader />);
+    const node = screen.getByRole('status');
+    expect(node).toHaveAttribute('aria-busy', 'true');
+    expect(node).toHaveAttribute('aria-label', '読み込み中');
+    expect(node.className).toContain('animate-pulse');
+  });
+
+  it('applies the rectangle variant class', () => {
+    render(<SkeletonLoader variant="rectangle" data-testid="sk" />);
+    const node = screen.getByRole('status');
+    expect(node.className).toContain('rounded-md');
+  });
+
+  it('applies the circle variant class', () => {
+    render(<SkeletonLoader variant="circle" />);
+    const node = screen.getByRole('status');
+    expect(node.className).toContain('rounded-full');
+  });
+
+  it('renders width/height as inline styles', () => {
+    render(<SkeletonLoader width={120} height="2rem" />);
+    const node = screen.getByRole('status');
+    expect((node as HTMLElement).style.width).toBe('120px');
+    expect((node as HTMLElement).style.height).toBe('2rem');
+  });
+
+  it('renders multiple lines when count > 1', () => {
+    render(<SkeletonLoader count={3} />);
+    const wrapper = screen.getByRole('status');
+    const lines = wrapper.querySelectorAll('[aria-hidden="true"]');
+    expect(lines.length).toBe(3);
+  });
+
+  it('treats invalid count values as a single skeleton', () => {
+    render(<SkeletonLoader count={0} />);
+    const wrapper = screen.getByRole('status');
+    expect(wrapper.className).toContain('animate-pulse');
+  });
+
+  it('includes motion-reduce class for reduced-motion users', () => {
+    render(<SkeletonLoader />);
+    const node = screen.getByRole('status');
+    expect(node.className).toContain('motion-reduce:animate-none');
+  });
+});

--- a/src/components/feedback/SkeletonLoader.tsx
+++ b/src/components/feedback/SkeletonLoader.tsx
@@ -1,0 +1,80 @@
+import type { CSSProperties } from 'react';
+import { cn } from '@/lib/utils';
+
+export type SkeletonVariant = 'text' | 'rectangle' | 'circle';
+
+export interface SkeletonLoaderProps {
+  variant?: SkeletonVariant;
+  width?: string | number;
+  height?: string | number;
+  className?: string;
+  count?: number;
+}
+
+const variantClass: Record<SkeletonVariant, string> = {
+  text: 'rounded h-4',
+  rectangle: 'rounded-md',
+  circle: 'rounded-full',
+};
+
+const toCssSize = (value: string | number | undefined): string | undefined => {
+  if (value === undefined) return undefined;
+  return typeof value === 'number' ? `${value}px` : value;
+};
+
+export function SkeletonLoader({
+  variant = 'text',
+  width,
+  height,
+  className,
+  count = 1,
+}: SkeletonLoaderProps) {
+  const safeCount = Math.max(1, Math.floor(count));
+
+  const style: CSSProperties = {
+    width: toCssSize(width),
+    height: toCssSize(height),
+  };
+
+  if (safeCount === 1) {
+    return (
+      <span
+        role="status"
+        aria-busy="true"
+        aria-live="polite"
+        aria-label="読み込み中"
+        className={cn(
+          'block bg-gray-200 animate-pulse motion-reduce:animate-none',
+          variantClass[variant],
+          className,
+        )}
+        style={style}
+      />
+    );
+  }
+
+  return (
+    <span
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+      aria-label="読み込み中"
+      className="block space-y-2"
+    >
+      {Array.from({ length: safeCount }).map((_, index) => (
+        <span
+          key={index}
+          aria-hidden="true"
+          className={cn(
+            'block bg-gray-200 animate-pulse motion-reduce:animate-none',
+            variantClass[variant],
+            className,
+          )}
+          style={style}
+        />
+      ))}
+    </span>
+  );
+}
+
+export default SkeletonLoader;

--- a/src/components/feedback/SkeletonLoader.tsx
+++ b/src/components/feedback/SkeletonLoader.tsx
@@ -29,7 +29,9 @@ export function SkeletonLoader({
   className,
   count = 1,
 }: SkeletonLoaderProps) {
-  const safeCount = Math.max(1, Math.floor(count));
+  const MAX_SKELETONS = 50;
+  const normalized = Number.isFinite(count) ? Math.max(1, Math.floor(count)) : 1;
+  const safeCount = Math.min(MAX_SKELETONS, normalized);
 
   const style: CSSProperties = {
     width: toCssSize(width),

--- a/src/hooks/useReducedMotion.test.ts
+++ b/src/hooks/useReducedMotion.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useReducedMotion } from './useReducedMotion';
+
+const createMock = (matches: boolean) => ({
+  matches,
+  media: '(prefers-reduced-motion: reduce)',
+  onchange: null,
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  dispatchEvent: vi.fn(),
+});
+
+describe('useReducedMotion', () => {
+  beforeEach(() => {
+    window.matchMedia = vi.fn(() => createMock(false)) as unknown as typeof window.matchMedia;
+  });
+
+  it('returns false when prefers-reduced-motion is not set', () => {
+    const { result } = renderHook(() => useReducedMotion());
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true when prefers-reduced-motion is reduce', () => {
+    window.matchMedia = vi.fn(() => createMock(true)) as unknown as typeof window.matchMedia;
+    const { result } = renderHook(() => useReducedMotion());
+    expect(result.current).toBe(true);
+  });
+
+  it('subscribes to the prefers-reduced-motion media query', () => {
+    const mock = createMock(false);
+    window.matchMedia = vi.fn(() => mock) as unknown as typeof window.matchMedia;
+    renderHook(() => useReducedMotion());
+    expect(mock.addEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+  });
+});

--- a/src/hooks/useReducedMotion.test.ts
+++ b/src/hooks/useReducedMotion.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useReducedMotion } from './useReducedMotion';
+
+const originalMatchMedia = window.matchMedia;
 
 const createMock = (matches: boolean) => ({
   matches,
@@ -16,6 +18,11 @@ const createMock = (matches: boolean) => ({
 describe('useReducedMotion', () => {
   beforeEach(() => {
     window.matchMedia = vi.fn(() => createMock(false)) as unknown as typeof window.matchMedia;
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+    vi.restoreAllMocks();
   });
 
   it('returns false when prefers-reduced-motion is not set', () => {

--- a/src/hooks/useReducedMotion.ts
+++ b/src/hooks/useReducedMotion.ts
@@ -1,0 +1,31 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+const QUERY = '(prefers-reduced-motion: reduce)';
+
+const getInitialMatches = (): boolean => {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false;
+  }
+  return window.matchMedia(QUERY).matches;
+};
+
+export const useReducedMotion = (): boolean => {
+  const [prefersReduced, setPrefersReduced] = useState<boolean>(getInitialMatches);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
+    const mql = window.matchMedia(QUERY);
+    const handler = (event: MediaQueryListEvent) => setPrefersReduced(event.matches);
+    setPrefersReduced(mql.matches);
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, []);
+
+  return prefersReduced;
+};
+
+export default useReducedMotion;


### PR DESCRIPTION
## Summary
Issue #67 (Phase 2.3 UI/UX 改善) の **PR B: アニメーション & ローディング** です。  
PR A (レスポンシブ強化) に続く 2 本目の分割 PR で、独立してマージ可能です。

### 追加コンポーネント

| コンポーネント | 用途 |
|---|---|
| `FadeIn` | マウント時にふわっと表示。`duration` / `delay` / `as` をサポート |
| `SlideIn` | `top`/`bottom`/`left`/`right` 方向のスライド。距離・遅延もカスタマイズ可 |
| `SkeletonLoader` | `text`/`rectangle`/`circle` バリアント。`count` で複数行サポート |
| `Loading` | `Loader2` + メッセージの統一スピナー。`fullScreen` オーバーレイあり |

### 既存ページへの適用
- `dashboard/page.tsx`: ウェルカム/Quick Actions/Getting Started を段階的にフェード&スライドイン
- `history/page.tsx`: 統計カード・カレンダー領域をアニメ化、詳細パネルを右からスライドイン (日付切替時に再生)
- `profile/page.tsx`: プロフィールカードをフェードイン

### アクセシビリティ
- 全アニメーションは `motion-reduce:` ユーティリティで `prefers-reduced-motion` を尊重
- `SkeletonLoader` / `Loading` は `role="status"` + `aria-busy` + `aria-live="polite"` を付与

### 補足
- `src/app/history/page.tsx` の未使用 import (`format` / `parseISO` / `ja`) を削除 (lint 0 warnings 維持)

## Test plan
- [x] `npx vitest run src/components/animations src/components/feedback` で新規 26 テスト pass
- [x] フルテスト: 306 passed / 6 skipped (既存の `authStore` タイムアウト 1 件失敗は本 PR 無関係)
- [x] `npx eslint` 変更ファイル全て warnings/errors なし
- [ ] dev サーバーで `dashboard` / `history` / `profile` の表示確認
- [ ] OS レベルで「視差効果を減らす」を有効にしアニメーションが抑制されることを確認

https://claude.ai/code/session_01789bk14oLFGxu5bwWAj9Gv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI sections now animate on entry (fade/slide) across Dashboard, History, and Profile; animations respect reduced-motion preferences.
  * New reusable FadeIn and SlideIn animation components and a useReducedMotion hook.
  * New Loading component (sizes, accessible status, optional full-screen) and SkeletonLoader (text/rectangle/circle, count/size).

* **Tests**
  * Added comprehensive tests covering animations, loading UI, skeletons, and reduced-motion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->