### PR TITLE
feat(a11y): アクセシビリティ改善とタイポグラフィ強化 (PR C)

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -28,17 +28,21 @@ export default function DashboardPage() {
   if (error && !isLoading) {
     return (
       <div className="min-h-screen bg-[#fafafa] flex items-center justify-center p-4">
-        <div className="max-w-md w-full bg-white border border-red-200 rounded-lg p-6">
+        <div
+          role="alert"
+          aria-live="assertive"
+          className="max-w-md w-full bg-white border border-red-200 rounded-lg p-6"
+        >
           <div className="text-center">
-            <div className="text-red-600 text-lg font-semibold mb-2">
+            <div className="text-red-700 text-lg font-semibold mb-2">
               エラーが発生しました
             </div>
-            <p className="text-gray-600 mb-4">{error}</p>
+            <p className="text-gray-700 mb-4">{error}</p>
             <button
               onClick={() => {
                 window.location.reload();
               }}
-              className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+              className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
             >
               再読み込み
             </button>
@@ -73,57 +77,57 @@ export default function DashboardPage() {
           <h2 className="text-xl font-semibold text-gray-900 mb-2">
             振り返りを始めましょう
           </h2>
-          <p className="text-gray-600">
+          <p className="text-gray-700">
             3分で今週の振り返りを記録し、継続的な成長を実現しましょう。
           </p>
         </div>
 
         {/* Quick Actions */}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
+        <nav aria-label="クイックアクション" className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
           {/* 新しい振り返り */}
-          <Link href="/reflection">
+          <Link href="/reflection" aria-label="新しい振り返り: 今週の振り返りを作成">
             <Card className="cursor-pointer hover:shadow-md transition-shadow h-full">
               <CardContent className="p-6 text-center">
-                <PlusCircle className="w-8 h-8 text-blue-500 mx-auto mb-3" />
+                <PlusCircle className="w-8 h-8 text-blue-600 mx-auto mb-3" aria-hidden="true" />
                 <h3 className="font-semibold mb-2">新しい振り返り</h3>
-                <p className="text-sm text-gray-600">今週の振り返りを作成</p>
+                <p className="text-sm text-gray-700">今週の振り返りを作成</p>
               </CardContent>
             </Card>
           </Link>
 
           {/* 履歴を見る */}
-          <Link href="/history">
+          <Link href="/history" aria-label="履歴を見る: 過去の振り返りを確認">
             <Card className="cursor-pointer hover:shadow-md transition-shadow h-full">
               <CardContent className="p-6 text-center">
-                <Calendar className="w-8 h-8 text-green-500 mx-auto mb-3" />
+                <Calendar className="w-8 h-8 text-green-700 mx-auto mb-3" aria-hidden="true" />
                 <h3 className="font-semibold mb-2">履歴を見る</h3>
-                <p className="text-sm text-gray-600">過去の振り返りを確認</p>
+                <p className="text-sm text-gray-700">過去の振り返りを確認</p>
               </CardContent>
             </Card>
           </Link>
 
           {/* 統計を見る */}
-          <Link href="/analytics">
+          <Link href="/analytics" aria-label="統計を見る: 成長の記録を確認">
             <Card className="cursor-pointer hover:shadow-md transition-shadow h-full">
               <CardContent className="p-6 text-center">
-                <BarChart3 className="w-8 h-8 text-purple-500 mx-auto mb-3" />
+                <BarChart3 className="w-8 h-8 text-purple-700 mx-auto mb-3" aria-hidden="true" />
                 <h3 className="font-semibold mb-2">統計を見る</h3>
-                <p className="text-sm text-gray-600">成長の記録を確認</p>
+                <p className="text-sm text-gray-700">成長の記録を確認</p>
               </CardContent>
             </Card>
           </Link>
 
           {/* 設定 */}
-          <Link href="/profile">
+          <Link href="/profile" aria-label="設定: プロフィール設定">
             <Card className="cursor-pointer hover:shadow-md transition-shadow h-full">
               <CardContent className="p-6 text-center">
-                <Settings className="w-8 h-8 text-gray-500 mx-auto mb-3" />
+                <Settings className="w-8 h-8 text-gray-700 mx-auto mb-3" aria-hidden="true" />
                 <h3 className="font-semibold mb-2">設定</h3>
-                <p className="text-sm text-gray-600">プロフィール設定</p>
+                <p className="text-sm text-gray-700">プロフィール設定</p>
               </CardContent>
             </Card>
           </Link>
-        </div>
+        </nav>
 
         {/* Getting Started */}
         <Card>
@@ -131,43 +135,52 @@ export default function DashboardPage() {
             <CardTitle>はじめに</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="space-y-4">
-              <div className="flex items-start gap-3">
-                <div className="flex-shrink-0 w-6 h-6 bg-blue-100 text-blue-600 rounded-full flex items-center justify-center text-sm font-medium">
+            <ol className="space-y-4">
+              <li className="flex items-start gap-3">
+                <div
+                  aria-hidden="true"
+                  className="flex-shrink-0 w-6 h-6 bg-blue-100 text-blue-700 rounded-full flex items-center justify-center text-sm font-semibold"
+                >
                   1
                 </div>
                 <div>
                   <h4 className="font-medium">振り返りフレームワークを選択</h4>
-                  <p className="text-sm text-gray-600">
+                  <p className="text-sm text-gray-700">
                     YWT、KPT、DAKI、STAR、WLTなど、7種類のフレームワークから目的に合ったものを選択できます
                   </p>
                 </div>
-              </div>
-              
-              <div className="flex items-start gap-3">
-                <div className="flex-shrink-0 w-6 h-6 bg-blue-100 text-blue-600 rounded-full flex items-center justify-center text-sm font-medium">
+              </li>
+
+              <li className="flex items-start gap-3">
+                <div
+                  aria-hidden="true"
+                  className="flex-shrink-0 w-6 h-6 bg-blue-100 text-blue-700 rounded-full flex items-center justify-center text-sm font-semibold"
+                >
                   2
                 </div>
                 <div>
                   <h4 className="font-medium">3分で振り返りを記録</h4>
-                  <p className="text-sm text-gray-600">
+                  <p className="text-sm text-gray-700">
                     各項目に思ったことを気軽に記入してください。完璧である必要はありません
                   </p>
                 </div>
-              </div>
-              
-              <div className="flex items-start gap-3">
-                <div className="flex-shrink-0 w-6 h-6 bg-blue-100 text-blue-600 rounded-full flex items-center justify-center text-sm font-medium">
+              </li>
+
+              <li className="flex items-start gap-3">
+                <div
+                  aria-hidden="true"
+                  className="flex-shrink-0 w-6 h-6 bg-blue-100 text-blue-700 rounded-full flex items-center justify-center text-sm font-semibold"
+                >
                   3
                 </div>
                 <div>
                   <h4 className="font-medium">継続して成長を実感</h4>
-                  <p className="text-sm text-gray-600">
+                  <p className="text-sm text-gray-700">
                     週1回の振り返りを続けることで、確実な成長を実感できます
                   </p>
                 </div>
-              </div>
-            </div>
+              </li>
+            </ol>
           </CardContent>
         </Card>
       </main>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -113,7 +113,35 @@
 }
 
 @layer base {
+  html {
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
+  }
+
   body {
     @apply bg-background text-foreground;
+    font-family: var(--font-geist-sans),
+      "Hiragino Kaku Gothic ProN", "Hiragino Sans", "Yu Gothic UI", "Yu Gothic",
+      Meiryo, system-ui, sans-serif;
+    font-feature-settings: "palt" 1;
+    line-height: 1.7;
+    word-break: normal;
+    overflow-wrap: anywhere;
+    line-break: strict;
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    line-height: 1.4;
+    letter-spacing: 0.01em;
+  }
+
+  p {
+    line-height: 1.75;
+  }
+
+  :where(a, button, input, select, textarea, [tabindex]):focus-visible {
+    outline: 2px solid oklch(0.55 0.2 255);
+    outline-offset: 2px;
+    border-radius: 2px;
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -120,6 +120,7 @@
 
   body {
     @apply bg-background text-foreground;
+
     font-family: var(--font-geist-sans),
       "Hiragino Kaku Gothic ProN", "Hiragino Sans", "Yu Gothic UI", "Yu Gothic",
       Meiryo, system-ui, sans-serif;

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -10,8 +10,6 @@ import { reflectionService } from '@/services/reflectionService';
 import type { Reflection } from '@/types/reflection';
 import type { Framework } from '@/types/framework';
 import { X, ChevronRight } from 'lucide-react';
-import { format, parseISO } from 'date-fns';
-import { ja } from 'date-fns/locale';
 
 interface ReflectionDetail {
   date: Date;
@@ -148,21 +146,25 @@ export default function HistoryPage() {
       <main className="max-w-7xl mx-auto px-4 py-8">
         {/* Error Message */}
         {error && (
-          <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-lg">
+          <div
+            role="alert"
+            aria-live="assertive"
+            className="mb-6 p-4 bg-red-50 border border-red-200 rounded-lg"
+          >
             <p className="text-red-800">{error}</p>
           </div>
         )}
 
         {/* Stats */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
+        <section aria-label="振り返り統計" className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
           <div className="bg-white rounded-lg shadow-sm p-6">
-            <p className="text-sm text-gray-600 mb-1">総振り返り数</p>
-            <p className="text-3xl font-bold text-gray-900">{reflections.length}</p>
+            <p className="text-sm text-gray-700 mb-1" id="stat-total">総振り返り数</p>
+            <p className="text-3xl font-bold text-gray-900" aria-labelledby="stat-total">{reflections.length}</p>
           </div>
 
           <div className="bg-white rounded-lg shadow-sm p-6">
-            <p className="text-sm text-gray-600 mb-1">今月の振り返り</p>
-            <p className="text-3xl font-bold text-gray-900">
+            <p className="text-sm text-gray-700 mb-1" id="stat-month">今月の振り返り</p>
+            <p className="text-3xl font-bold text-gray-900" aria-labelledby="stat-month">
               {reflections.filter((r) => {
                 const date = new Date(r.reflection_date);
                 const now = new Date();
@@ -175,20 +177,20 @@ export default function HistoryPage() {
           </div>
 
           <div className="bg-white rounded-lg shadow-sm p-6">
-            <p className="text-sm text-gray-600 mb-1">継続日数</p>
-            <p className="text-3xl font-bold text-gray-900">
+            <p className="text-sm text-gray-700 mb-1" id="stat-streak">継続日数</p>
+            <p className="text-3xl font-bold text-gray-900" aria-labelledby="stat-streak">
               {new Set(reflections.map((r) => r.reflection_date)).size}
             </p>
           </div>
-        </div>
+        </section>
 
         {/* Calendar and Detail View - Side by side */}
         {reflections.length === 0 ? (
           <div className="bg-white rounded-lg shadow-sm p-12 text-center">
-            <p className="text-gray-600 mb-4">まだ振り返りがありません</p>
+            <p className="text-gray-700 mb-4">まだ振り返りがありません</p>
             <button
               onClick={() => router.push('/reflection')}
-              className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+              className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
             >
               最初の振り返りを作成
             </button>
@@ -214,10 +216,10 @@ export default function HistoryPage() {
                   </h2>
                   <button
                     onClick={closeDetail}
-                    className="p-2 hover:bg-gray-100 rounded-full transition-colors lg:hidden"
-                    aria-label="閉じる"
+                    className="p-2 hover:bg-gray-100 rounded-full transition-colors lg:hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+                    aria-label="詳細パネルを閉じる"
                   >
-                    <X className="w-5 h-5 text-gray-500" />
+                    <X className="w-5 h-5 text-gray-700" aria-hidden="true" />
                   </button>
                 </div>
 
@@ -284,18 +286,19 @@ export default function HistoryPage() {
 
                         {/* Metadata */}
                         <div className="mt-4 pt-4 border-t border-gray-200 flex items-center justify-between">
-                          <div className="text-xs text-gray-500">
+                          <div className="text-xs text-gray-700">
                             作成日: {reflection.created_at?.split('T')[0] || reflection.reflection_date}
                           </div>
 
                           {/* Detail View Button */}
                           <button
                             onClick={() => router.push(`/history/${reflection.id}`)}
-                            className="flex items-center gap-1 text-blue-600 hover:text-blue-700 hover:underline transition-colors text-sm font-medium"
+                            className="flex items-center gap-1 text-blue-700 hover:text-blue-800 hover:underline transition-colors text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 rounded"
+                            aria-label={`${framework?.display_name || '振り返り'}の詳細ページへ`}
                             title="詳細ページで編集可能です"
                           >
                             詳細表示
-                            <ChevronRight className="w-4 h-4" />
+                            <ChevronRight className="w-4 h-4" aria-hidden="true" />
                           </button>
                         </div>
                       </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { SessionProvider } from "@/components/providers/SessionProvider";
 import { ToastProvider } from "@/components/providers/ToastProvider";
 import ErrorBoundary from "@/components/common/ErrorBoundary";
 import Footer from "@/components/layout/Footer";
+import { SkipLink } from "@/components/a11y/SkipLink";
 import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 
@@ -68,10 +69,11 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased flex flex-col min-h-screen`}
       >
+        <SkipLink />
         <ErrorBoundary>
           <SessionProvider>
             <ToastProvider>
-              <div className="flex-1 flex flex-col">
+              <div id="main-content" className="flex-1 flex flex-col">
                 {children}
               </div>
               <Footer />

--- a/src/components/a11y/SkipLink.test.tsx
+++ b/src/components/a11y/SkipLink.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SkipLink } from './SkipLink';
+
+describe('SkipLink', () => {
+  it('renders default link pointing to #main-content', () => {
+    render(<SkipLink />);
+    const link = screen.getByRole('link', { name: 'メインコンテンツへスキップ' });
+    expect(link).toHaveAttribute('href', '#main-content');
+  });
+
+  it('uses the sr-only class so it is visually hidden until focused', () => {
+    render(<SkipLink />);
+    const link = screen.getByRole('link', { name: 'メインコンテンツへスキップ' });
+    expect(link.className).toContain('sr-only');
+    expect(link.className).toContain('focus-visible:not-sr-only');
+  });
+
+  it('supports a custom href and children', () => {
+    render(<SkipLink href="#content">本文へスキップ</SkipLink>);
+    const link = screen.getByRole('link', { name: '本文へスキップ' });
+    expect(link).toHaveAttribute('href', '#content');
+  });
+
+  it('merges a custom className', () => {
+    render(<SkipLink className="custom-class" />);
+    const link = screen.getByRole('link', { name: 'メインコンテンツへスキップ' });
+    expect(link.className).toContain('custom-class');
+  });
+});

--- a/src/components/a11y/SkipLink.tsx
+++ b/src/components/a11y/SkipLink.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+export interface SkipLinkProps {
+  href?: string;
+  children?: ReactNode;
+  className?: string;
+}
+
+export function SkipLink({
+  href = '#main-content',
+  children = 'メインコンテンツへスキップ',
+  className,
+}: SkipLinkProps) {
+  return (
+    <a
+      href={href}
+      className={cn(
+        'sr-only focus-visible:not-sr-only',
+        'focus-visible:fixed focus-visible:top-2 focus-visible:left-2 focus-visible:z-50',
+        'focus-visible:px-4 focus-visible:py-2',
+        'focus-visible:bg-blue-600 focus-visible:text-white',
+        'focus-visible:rounded-md focus-visible:shadow-lg',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-blue-600',
+        className,
+      )}
+    >
+      {children}
+    </a>
+  );
+}
+
+export default SkipLink;

--- a/src/components/a11y/VisuallyHidden.test.tsx
+++ b/src/components/a11y/VisuallyHidden.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { VisuallyHidden } from './VisuallyHidden';
+
+describe('VisuallyHidden', () => {
+  it('renders children inside a span with sr-only by default', () => {
+    render(<VisuallyHidden>保存しました</VisuallyHidden>);
+    const el = screen.getByText('保存しました');
+    expect(el.tagName.toLowerCase()).toBe('span');
+    expect(el.className).toContain('sr-only');
+  });
+
+  it('renders as a custom element when `as` is provided', () => {
+    render(<VisuallyHidden as="p">説明テキスト</VisuallyHidden>);
+    const el = screen.getByText('説明テキスト');
+    expect(el.tagName.toLowerCase()).toBe('p');
+    expect(el.className).toContain('sr-only');
+  });
+
+  it('merges a custom className', () => {
+    render(<VisuallyHidden className="extra">ラベル</VisuallyHidden>);
+    const el = screen.getByText('ラベル');
+    expect(el.className).toContain('sr-only');
+    expect(el.className).toContain('extra');
+  });
+});

--- a/src/components/a11y/VisuallyHidden.tsx
+++ b/src/components/a11y/VisuallyHidden.tsx
@@ -1,0 +1,18 @@
+import type { ElementType, ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+export interface VisuallyHiddenProps {
+  children: ReactNode;
+  as?: ElementType;
+  className?: string;
+}
+
+export function VisuallyHidden({
+  children,
+  as: Component = 'span',
+  className,
+}: VisuallyHiddenProps) {
+  return <Component className={cn('sr-only', className)}>{children}</Component>;
+}
+
+export default VisuallyHidden;

--- a/src/components/layout/Header/LoggedInHeader.tsx
+++ b/src/components/layout/Header/LoggedInHeader.tsx
@@ -44,9 +44,10 @@ export default function LoggedInHeader({
             {showBackButton && (
               <Link
                 href={backHref}
-                className="flex items-center gap-1 text-gray-600 hover:text-gray-900 flex-shrink-0"
+                aria-label="前の画面に戻る"
+                className="flex items-center gap-1 text-gray-700 hover:text-gray-900 flex-shrink-0"
               >
-                <ArrowLeft className="w-5 h-5" />
+                <ArrowLeft className="w-5 h-5" aria-hidden="true" />
                 <span className="text-xs sm:text-sm">戻る</span>
               </Link>
             )}
@@ -56,9 +57,9 @@ export default function LoggedInHeader({
           </div>
 
           {/* 右側：ユーザー名 + お問い合わせ + ログアウト */}
-          <div className="flex items-center gap-2 sm:gap-4 flex-shrink-0">
-            <div className="hidden sm:flex items-center gap-2 text-gray-600">
-              <User className="w-4 h-4" />
+          <nav aria-label="ユーザーメニュー" className="flex items-center gap-2 sm:gap-4 flex-shrink-0">
+            <div className="hidden sm:flex items-center gap-2 text-gray-700">
+              <User className="w-4 h-4" aria-hidden="true" />
               <span className="text-sm">{userName}</span>
             </div>
             {contactUrl && isValidUrl(contactUrl) && (
@@ -66,10 +67,10 @@ export default function LoggedInHeader({
                 href={contactUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                aria-label="お問い合わせ"
-                className="flex items-center gap-1 sm:gap-2 text-gray-600 hover:text-blue-600 transition px-2 sm:px-3 py-1.5 rounded-md hover:bg-gray-50"
+                aria-label="お問い合わせ (新しいタブで開く)"
+                className="flex items-center gap-1 sm:gap-2 text-gray-700 hover:text-blue-700 transition px-2 sm:px-3 py-1.5 rounded-md hover:bg-gray-50"
               >
-                <Mail className="w-4 h-4" />
+                <Mail className="w-4 h-4" aria-hidden="true" />
                 <span className="hidden sm:inline text-sm">お問い合わせ</span>
               </a>
             )}
@@ -78,23 +79,25 @@ export default function LoggedInHeader({
               variant="outline"
               size="sm"
               disabled={isLoading}
-              className="text-gray-600 hover:text-gray-800 px-2 sm:px-3"
+              aria-busy={isLoading}
+              aria-label={isLoading ? 'ログアウト中' : 'ログアウト'}
+              className="text-gray-700 hover:text-gray-900 px-2 sm:px-3"
             >
               {isLoading ? (
-                <Loader2 className="w-4 h-4 animate-spin" />
+                <Loader2 className="w-4 h-4 animate-spin motion-reduce:animate-none" aria-hidden="true" />
               ) : (
-                <LogOut className="w-4 h-4" />
+                <LogOut className="w-4 h-4" aria-hidden="true" />
               )}
               <span className="hidden sm:inline ml-2">
                 {isLoading ? 'ログアウト中...' : 'ログアウト'}
               </span>
             </Button>
-          </div>
+          </nav>
         </div>
 
         {/* モバイル用ユーザー表示 */}
-        <div className="sm:hidden flex items-center gap-2 text-gray-600 text-xs mt-2">
-          <User className="w-3 h-3" />
+        <div className="sm:hidden flex items-center gap-2 text-gray-700 text-xs mt-2">
+          <User className="w-3 h-3" aria-hidden="true" />
           <span>{userName}</span>
         </div>
       </div>

--- a/src/components/layout/Header/LoggedOutHeader.tsx
+++ b/src/components/layout/Header/LoggedOutHeader.tsx
@@ -37,16 +37,17 @@ export default function LoggedOutHeader({
                 <span className="hidden sm:inline text-sm">お問い合わせ</span>
               </a>
             )}
-            <Link href="/auth" aria-label="ログインページへ移動">
-              <Button
-                variant="default"
-                size="sm"
-                className="bg-blue-600 hover:bg-blue-700"
-              >
+            <Button
+              asChild
+              variant="default"
+              size="sm"
+              className="bg-blue-600 hover:bg-blue-700"
+            >
+              <Link href="/auth" aria-label="ログインページへ移動">
                 <LogIn className="w-4 h-4 mr-2" aria-hidden="true" />
                 ログイン
-              </Button>
-            </Link>
+              </Link>
+            </Button>
           </nav>
         </div>
       </div>

--- a/src/components/layout/Header/LoggedOutHeader.tsx
+++ b/src/components/layout/Header/LoggedOutHeader.tsx
@@ -20,34 +20,34 @@ export default function LoggedOutHeader({
         <div className="flex items-center justify-between">
           <div>
             <h1 className="text-2xl font-semibold text-gray-900">{title}</h1>
-            <p className="text-sm text-gray-600">
+            <p className="text-sm text-gray-700">
               自分の成長を記録しましょう
             </p>
           </div>
-          <div className="flex items-center gap-2 sm:gap-4">
+          <nav aria-label="ナビゲーション" className="flex items-center gap-2 sm:gap-4">
             {contactUrl && isValidUrl(contactUrl) && (
               <a
                 href={contactUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                aria-label="お問い合わせ"
-                className="flex items-center gap-1 sm:gap-2 text-gray-600 hover:text-blue-600 transition px-2 sm:px-3 py-1.5 rounded-md hover:bg-gray-50"
+                aria-label="お問い合わせ (新しいタブで開く)"
+                className="flex items-center gap-1 sm:gap-2 text-gray-700 hover:text-blue-700 transition px-2 sm:px-3 py-1.5 rounded-md hover:bg-gray-50"
               >
-                <Mail className="w-4 h-4" />
+                <Mail className="w-4 h-4" aria-hidden="true" />
                 <span className="hidden sm:inline text-sm">お問い合わせ</span>
               </a>
             )}
-            <Link href="/auth">
+            <Link href="/auth" aria-label="ログインページへ移動">
               <Button
                 variant="default"
                 size="sm"
                 className="bg-blue-600 hover:bg-blue-700"
               >
-                <LogIn className="w-4 h-4 mr-2" />
+                <LogIn className="w-4 h-4 mr-2" aria-hidden="true" />
                 ログイン
               </Button>
             </Link>
-          </div>
+          </nav>
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary

Issue #67 (Phase 2.3 UI/UX 改善) を 3 PR に分割した最後の PR C（アクセシビリティ & タイポグラフィ）です。PR A（レスポンシブ #75）、PR B（アニメーション #76）に続き、WCAG 2.1 AA 準拠を意識した全体改善を行いました。

### 主な変更

**a11y コンポーネント新設**
- `SkipLink`: キーボードユーザー向けにメインコンテンツへの一発ジャンプを提供（フォーカス時のみ可視）
- `VisuallyHidden`: スクリーンリーダー専用テキスト用の共通コンポーネント

**レイアウト / セマンティクス**
- `layout.tsx` の最上部に `<SkipLink />` を配置、コンテンツラッパーに `id="main-content"` を付与
- `LoggedInHeader` / `LoggedOutHeader` を `<nav aria-label="...">` でランドマーク化
- 装飾アイコン (lucide-react) に `aria-hidden="true"` を付与
- ログアウトボタンに `aria-busy` / `aria-label` を設定
- ダッシュボードのステップを `<ol>/<li>` へ、履歴の統計ブロックを `<section> + aria-labelledby` に変更
- エラー表示に `role="alert"` / `aria-live="assertive"` を追加

**タイポグラフィ (globals.css)**
- 日本語フォントスタック (Hiragino Kaku Gothic ProN, Hiragino Sans, Yu Gothic, Meiryo) を追加
- `font-feature-settings: "palt" 1` で欧文プロポーショナル詰めを有効化
- 本文 `line-height: 1.7`、見出し `1.4` / `letter-spacing: 0.01em`、段落 `1.75` を設定
- `overflow-wrap: anywhere` / `line-break: strict` で日本語折り返しを最適化
- `:focus-visible` にブルーのアウトラインを追加（キーボード操作時のみ表示）

**コントラスト改善（WCAG 2.1 AA 4.5:1 以上）**
- 本文系の `text-gray-600/500` を `text-gray-700` へ
- リンク／ボタンの `text-blue-600` → `text-blue-700`、`hover:text-blue-600` → `hover:text-blue-700`
- ダッシュボードカードの装飾アイコン色を `-500` から `-700` へ

### Test plan
- [x] `SkipLink` / `VisuallyHidden` の単体テストを追加（7 件パス）
- [x] 既存テスト 312 件パス（authStore の 1 件は pre-existing / 変更に無関係）
- [x] ESLint: エラーなし
- [ ] キーボード操作でスキップリンクが表示・機能することを手動確認
- [ ] スクリーンリーダー (VoiceOver / NVDA) でランドマーク・ラベルを確認

https://claude.ai/code/session_01789bk14oLFGxu5bwWAj9Gv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a keyboard "skip to main content" link and a visually-hidden helper to improve keyboard navigation and screen-reader experience
  * Enhanced focus-visible styles across interactive controls for clearer keyboard focus

* **Bug Fixes**
  * Improved screen-reader support with alert announcements, semantic landmarks, descriptive labels, and hidden decorative icons
  * Adjusted text and icon colors for more consistent contrast and theming; improved layout semantics for step lists

* **Tests**
  * Added tests covering the new accessibility components
<!-- end of auto-generated comment: release notes by coderabbit.ai -->