### PR TITLE
[Phase 2.4] エラーハンドリング強化 - エラーログ記録・監視機構・自動回復

### DIFF
--- a/src/app/api/logs/errors/route.test.ts
+++ b/src/app/api/logs/errors/route.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST, GET } from './route';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}));
+
+import { createClient } from '@/lib/supabase/server';
+
+const mockUserId = 'user-test-123';
+
+function makeSupabaseMock(overrides: Record<string, unknown> = {}) {
+  const mockInsert = vi.fn().mockResolvedValue({ error: null });
+  const mockSelect = vi.fn().mockReturnThis();
+  const mockEq = vi.fn().mockReturnThis();
+  const mockOrder = vi.fn().mockReturnThis();
+  const mockRange = vi.fn().mockResolvedValue({ data: [], error: null, count: 0 });
+
+  const fromMock = vi.fn().mockReturnValue({
+    insert: mockInsert,
+    select: mockSelect,
+    eq: mockEq,
+    order: mockOrder,
+    range: mockRange,
+  });
+
+  return {
+    auth: {
+      getSession: vi.fn().mockResolvedValue({
+        data: { session: { user: { id: mockUserId } } },
+        error: null,
+      }),
+    },
+    from: fromMock,
+    ...overrides,
+  };
+}
+
+describe('POST /api/logs/errors', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 400 when body is missing logs array', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (createClient as any).mockResolvedValue(makeSupabaseMock());
+
+    const req = new NextRequest('http://localhost/api/logs/errors', {
+      method: 'POST',
+      body: JSON.stringify({ sessionId: 'sess_1' }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe('Invalid request body');
+  });
+
+  it('returns 200 and received count on success', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (createClient as any).mockResolvedValue(makeSupabaseMock());
+
+    const logs = [
+      {
+        id: 'log1',
+        userId: mockUserId,
+        errorType: 'network',
+        message: 'Network error',
+        context: { page: '/', url: 'http://localhost/', timestamp: Date.now() },
+        severity: 'error',
+        resolved: false,
+        createdAt: Date.now(),
+      },
+    ];
+
+    const req = new NextRequest('http://localhost/api/logs/errors', {
+      method: 'POST',
+      body: JSON.stringify({ logs, sessionId: 'sess_1', batchId: 'b1', sentAt: Date.now() }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.success).toBe(true);
+    expect(data.received).toBe(1);
+  });
+
+  it('returns 500 when DB insert fails', async () => {
+    const supabase = makeSupabaseMock();
+    supabase.from.mockReturnValue({
+      insert: vi.fn().mockResolvedValue({ error: { message: 'DB error' } }),
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (createClient as any).mockResolvedValue(supabase);
+
+    const logs = [
+      {
+        id: 'log2',
+        errorType: 'server',
+        message: 'Server error',
+        context: { page: '/', url: 'http://localhost/', timestamp: Date.now() },
+        severity: 'critical',
+        resolved: false,
+        createdAt: Date.now(),
+      },
+    ];
+
+    const req = new NextRequest('http://localhost/api/logs/errors', {
+      method: 'POST',
+      body: JSON.stringify({ logs, sessionId: 'sess_1', batchId: 'b2', sentAt: Date.now() }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('GET /api/logs/errors', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    const supabase = makeSupabaseMock();
+    supabase.auth.getSession = vi.fn().mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (createClient as any).mockResolvedValue(supabase);
+
+    const req = new NextRequest('http://localhost/api/logs/errors');
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when user_id does not match session', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (createClient as any).mockResolvedValue(makeSupabaseMock());
+
+    const req = new NextRequest(
+      'http://localhost/api/logs/errors?user_id=other-user'
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns paginated logs for authenticated user', async () => {
+    const mockLogs = [{ id: 'l1', message: 'err', user_id: mockUserId }];
+    const supabase = makeSupabaseMock();
+    supabase.from.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      range: vi.fn().mockResolvedValue({ data: mockLogs, error: null, count: 1 }),
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (createClient as any).mockResolvedValue(supabase);
+
+    const req = new NextRequest(
+      `http://localhost/api/logs/errors?user_id=${mockUserId}`
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.logs).toHaveLength(1);
+    expect(data.total).toBe(1);
+  });
+});

--- a/src/app/api/logs/errors/route.ts
+++ b/src/app/api/logs/errors/route.ts
@@ -57,6 +57,7 @@ export async function POST(request: NextRequest) {
         typeof v.errorType === 'string' &&
         typeof v.message === 'string' &&
         typeof v.createdAt === 'number' &&
+        typeof v.severity === 'string' &&
         !!v.context &&
         typeof v.context === 'object'
       );

--- a/src/app/api/logs/errors/route.ts
+++ b/src/app/api/logs/errors/route.ts
@@ -27,7 +27,26 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
     }
 
-    const logs: ErrorLogEntry[] = body.logs.slice(0, MAX_BATCH_SIZE);
+    const candidateLogs = body.logs.slice(0, MAX_BATCH_SIZE);
+
+    const isValidLog = (log: unknown): log is ErrorLogEntry => {
+      if (!log || typeof log !== 'object') return false;
+      const v = log as Partial<ErrorLogEntry>;
+      return (
+        typeof v.id === 'string' &&
+        typeof v.errorType === 'string' &&
+        typeof v.message === 'string' &&
+        typeof v.createdAt === 'number' &&
+        !!v.context &&
+        typeof v.context === 'object'
+      );
+    };
+
+    if (!candidateLogs.every(isValidLog)) {
+      return NextResponse.json({ error: 'Invalid log entry' }, { status: 400 });
+    }
+
+    const logs: ErrorLogEntry[] = candidateLogs;
 
     const supabase = await createClient();
     const {

--- a/src/app/api/logs/errors/route.ts
+++ b/src/app/api/logs/errors/route.ts
@@ -1,8 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-import type { ErrorLogBatch, ErrorLogEntry } from '@/types/errorTracking';
+import type { ErrorLogBatch, ErrorLogEntry, PersistedErrorLog } from '@/types/errorTracking';
 
 const MAX_BATCH_SIZE = 50;
+
+function parsePositiveInt(value: string | null, fallback: number): number {
+  const parsed = Number.parseInt(value ?? '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function safeToISOString(timestamp: number): string | null {
+  const d = new Date(timestamp);
+  return Number.isFinite(d.getTime()) ? d.toISOString() : null;
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -19,11 +29,12 @@ export async function POST(request: NextRequest) {
       data: { session },
     } = await supabase.auth.getSession();
 
-    const userId = session?.user?.id;
+    // Always use the server-verified userId; never trust client-supplied values.
+    const userId = session?.user?.id ?? null;
 
     const rows = logs.map((log) => ({
       id: log.id,
-      user_id: userId ?? log.userId ?? null,
+      user_id: userId,
       error_type: log.errorType,
       message: log.message,
       stack: log.stack ?? null,
@@ -36,13 +47,12 @@ export async function POST(request: NextRequest) {
       session_id: log.context?.sessionId ?? body.sessionId ?? null,
       metadata: log.metadata ?? null,
       resolved: false,
-      created_at: new Date(log.createdAt).toISOString(),
+      created_at: safeToISOString(log.createdAt) ?? new Date().toISOString(),
     }));
 
     const { error } = await supabase.from('error_logs').insert(rows);
 
     if (error) {
-      // Still acknowledge receipt even if DB insert fails (avoid client retry loops)
       console.error('[ErrorLogs] DB insert failed:', error.message);
       return NextResponse.json(
         { success: false, received: 0, message: 'Storage error' },
@@ -70,8 +80,8 @@ export async function GET(request: NextRequest) {
 
     const { searchParams } = new URL(request.url);
     const userId = searchParams.get('user_id') ?? session.user.id;
-    const page = Math.max(1, parseInt(searchParams.get('page') ?? '1', 10));
-    const perPage = Math.min(100, Math.max(1, parseInt(searchParams.get('per_page') ?? '20', 10)));
+    const page = parsePositiveInt(searchParams.get('page'), 1);
+    const perPage = Math.min(100, parsePositiveInt(searchParams.get('per_page'), 20));
     const offset = (page - 1) * perPage;
 
     // Users can only access their own logs
@@ -79,7 +89,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
 
-    const { data: logs, error: logsError, count } = await supabase
+    const { data: rows, error: logsError, count } = await supabase
       .from('error_logs')
       .select('*', { count: 'exact' })
       .eq('user_id', userId)
@@ -90,12 +100,31 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Failed to fetch logs' }, { status: 500 });
     }
 
-    return NextResponse.json({
-      logs: logs ?? [],
-      total: count ?? 0,
-      page,
-      perPage,
-    });
+    const logs: PersistedErrorLog[] = (rows ?? []).map((row) => ({
+      id: row.id,
+      userId: row.user_id ?? undefined,
+      errorType: row.error_type,
+      message: row.message,
+      stack: row.stack ?? undefined,
+      statusCode: row.status_code ?? undefined,
+      severity: row.severity,
+      context: {
+        page: row.page ?? '',
+        action: row.action ?? undefined,
+        userId: row.user_id ?? undefined,
+        sessionId: row.session_id ?? undefined,
+        timestamp: new Date(row.created_at).getTime(),
+        userAgent: row.user_agent ?? undefined,
+        url: row.url ?? '',
+      },
+      metadata: row.metadata ?? undefined,
+      resolved: row.resolved ?? false,
+      resolvedAt: row.resolved_at ? new Date(row.resolved_at).getTime() : undefined,
+      resolvedBy: row.resolved_by ?? undefined,
+      createdAt: new Date(row.created_at).getTime(),
+    }));
+
+    return NextResponse.json({ logs, total: count ?? 0, page, perPage });
   } catch {
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }

--- a/src/app/api/logs/errors/route.ts
+++ b/src/app/api/logs/errors/route.ts
@@ -1,15 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-import type { ErrorLogBatch, ErrorLogEntry, PersistedErrorLog } from '@/types/errorTracking';
+import type {
+  ErrorCategory,
+  ErrorLogBatch,
+  ErrorLogEntry,
+  ErrorSeverity,
+  PersistedErrorLog,
+} from '@/types/errorTracking';
 
 type DbErrorLogRow = {
   id: string;
   user_id: string | null;
-  error_type: string;
+  error_type: ErrorCategory;
   message: string;
   stack: string | null;
   status_code: number | null;
-  severity: string;
+  severity: ErrorSeverity;
   page: string | null;
   action: string | null;
   url: string | null;

--- a/src/app/api/logs/errors/route.ts
+++ b/src/app/api/logs/errors/route.ts
@@ -1,0 +1,102 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import type { ErrorLogBatch, ErrorLogEntry } from '@/types/errorTracking';
+
+const MAX_BATCH_SIZE = 50;
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json()) as ErrorLogBatch;
+
+    if (!body.logs || !Array.isArray(body.logs)) {
+      return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+    }
+
+    const logs: ErrorLogEntry[] = body.logs.slice(0, MAX_BATCH_SIZE);
+
+    const supabase = await createClient();
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+
+    const userId = session?.user?.id;
+
+    const rows = logs.map((log) => ({
+      id: log.id,
+      user_id: userId ?? log.userId ?? null,
+      error_type: log.errorType,
+      message: log.message,
+      stack: log.stack ?? null,
+      status_code: log.statusCode ?? null,
+      severity: log.severity,
+      page: log.context?.page ?? null,
+      action: log.context?.action ?? null,
+      url: log.context?.url ?? null,
+      user_agent: log.context?.userAgent ?? null,
+      session_id: log.context?.sessionId ?? body.sessionId ?? null,
+      metadata: log.metadata ?? null,
+      resolved: false,
+      created_at: new Date(log.createdAt).toISOString(),
+    }));
+
+    const { error } = await supabase.from('error_logs').insert(rows);
+
+    if (error) {
+      // Still acknowledge receipt even if DB insert fails (avoid client retry loops)
+      console.error('[ErrorLogs] DB insert failed:', error.message);
+      return NextResponse.json(
+        { success: false, received: 0, message: 'Storage error' },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ success: true, received: rows.length });
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { session },
+      error: sessionError,
+    } = await supabase.auth.getSession();
+
+    if (sessionError || !session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const userId = searchParams.get('user_id') ?? session.user.id;
+    const page = Math.max(1, parseInt(searchParams.get('page') ?? '1', 10));
+    const perPage = Math.min(100, Math.max(1, parseInt(searchParams.get('per_page') ?? '20', 10)));
+    const offset = (page - 1) * perPage;
+
+    // Users can only access their own logs
+    if (userId !== session.user.id) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const { data: logs, error: logsError, count } = await supabase
+      .from('error_logs')
+      .select('*', { count: 'exact' })
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+      .range(offset, offset + perPage - 1);
+
+    if (logsError) {
+      return NextResponse.json({ error: 'Failed to fetch logs' }, { status: 500 });
+    }
+
+    return NextResponse.json({
+      logs: logs ?? [],
+      total: count ?? 0,
+      page,
+      perPage,
+    });
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/logs/errors/route.ts
+++ b/src/app/api/logs/errors/route.ts
@@ -15,9 +15,14 @@ function safeToISOString(timestamp: number): string | null {
 }
 
 export async function POST(request: NextRequest) {
+  let body: ErrorLogBatch;
   try {
-    const body = (await request.json()) as ErrorLogBatch;
+    body = (await request.json()) as ErrorLogBatch;
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+  }
 
+  try {
     if (!body.logs || !Array.isArray(body.logs)) {
       return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
     }

--- a/src/app/api/logs/errors/route.ts
+++ b/src/app/api/logs/errors/route.ts
@@ -2,6 +2,26 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import type { ErrorLogBatch, ErrorLogEntry, PersistedErrorLog } from '@/types/errorTracking';
 
+type DbErrorLogRow = {
+  id: string;
+  user_id: string | null;
+  error_type: string;
+  message: string;
+  stack: string | null;
+  status_code: number | null;
+  severity: string;
+  page: string | null;
+  action: string | null;
+  url: string | null;
+  user_agent: string | null;
+  session_id: string | null;
+  metadata: Record<string, unknown> | null;
+  resolved: boolean | null;
+  resolved_at: string | null;
+  resolved_by: string | null;
+  created_at: string;
+};
+
 const MAX_BATCH_SIZE = 50;
 
 function parsePositiveInt(value: string | null, fallback: number): number {
@@ -124,7 +144,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Failed to fetch logs' }, { status: 500 });
     }
 
-    const logs: PersistedErrorLog[] = (rows ?? []).map((row) => ({
+    const logs: PersistedErrorLog[] = ((rows ?? []) as DbErrorLogRow[]).map((row) => ({
       id: row.id,
       userId: row.user_id ?? undefined,
       errorType: row.error_type,

--- a/src/components/common/ServiceUnavailable.tsx
+++ b/src/components/common/ServiceUnavailable.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import React from 'react';
+
+interface ServiceUnavailableProps {
+  title?: string;
+  message?: string;
+  onRetry?: () => void;
+  showRetry?: boolean;
+}
+
+/**
+ * Fallback UI displayed when a service or feature is temporarily unavailable.
+ * Used for graceful degradation when backend services cannot be reached.
+ */
+const ServiceUnavailable: React.FC<ServiceUnavailableProps> = ({
+  title = 'サービスが利用できません',
+  message = 'このサービスは一時的に利用できない状態です。しばらく時間をおいてから再度お試しください。',
+  onRetry,
+  showRetry = true,
+}) => {
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      className="flex flex-col items-center justify-center gap-4 rounded-lg border border-gray-200 bg-gray-50 p-8 text-center"
+    >
+      <span className="text-4xl" aria-hidden="true">
+        🔧
+      </span>
+      <div className="space-y-1">
+        <h2 className="text-lg font-semibold text-gray-800">{title}</h2>
+        <p className="text-sm text-gray-600">{message}</p>
+      </div>
+      {showRetry && onRetry && (
+        <button
+          onClick={onRetry}
+          className="mt-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+        >
+          再試行
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default ServiceUnavailable;

--- a/src/hooks/useNetworkRecovery.ts
+++ b/src/hooks/useNetworkRecovery.ts
@@ -1,0 +1,104 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { retryWithNetworkRecovery } from '@/utils/errorHandler';
+
+export interface NetworkRecoveryState {
+  isOnline: boolean;
+  isRetrying: boolean;
+  retryCount: number;
+  lastError: Error | null;
+}
+
+export interface UseNetworkRecoveryOptions {
+  maxRetries?: number;
+  initialDelayMs?: number;
+  onRecovered?: () => void;
+  onFailed?: (error: Error) => void;
+}
+
+/**
+ * Hook for automatic network recovery and offline detection.
+ * Provides online/offline state and a wrapper for retrying failed operations.
+ */
+export function useNetworkRecovery(options: UseNetworkRecoveryOptions = {}) {
+  const { maxRetries = 3, initialDelayMs = 1000, onRecovered, onFailed } = options;
+
+  const [state, setState] = useState<NetworkRecoveryState>({
+    isOnline: typeof window !== 'undefined' ? window.navigator.onLine : true,
+    isRetrying: false,
+    retryCount: 0,
+    lastError: null,
+  });
+
+  const pendingOps = useRef<Array<() => Promise<unknown>>>([]);
+
+  useEffect(() => {
+    const handleOnline = () => {
+      setState((prev) => ({ ...prev, isOnline: true }));
+
+      // Flush any pending operations
+      const ops = pendingOps.current.splice(0);
+      ops.forEach((op) => op());
+
+      onRecovered?.();
+    };
+
+    const handleOffline = () => {
+      setState((prev) => ({ ...prev, isOnline: false }));
+    };
+
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, [onRecovered]);
+
+  const executeWithRecovery = useCallback(
+    async <T,>(operation: () => Promise<T>): Promise<T | null> => {
+      setState((prev) => ({ ...prev, isRetrying: true, lastError: null, retryCount: 0 }));
+
+      try {
+        const result = await retryWithNetworkRecovery(operation, maxRetries, initialDelayMs);
+        setState((prev) => ({ ...prev, isRetrying: false, retryCount: 0 }));
+        return result;
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        setState((prev) => ({
+          ...prev,
+          isRetrying: false,
+          lastError: err,
+          retryCount: prev.retryCount + 1,
+        }));
+        onFailed?.(err);
+        return null;
+      }
+    },
+    [maxRetries, initialDelayMs, onFailed]
+  );
+
+  const queueWhenOnline = useCallback(
+    <T,>(operation: () => Promise<T>): Promise<T | null> => {
+      if (state.isOnline) {
+        return executeWithRecovery(operation);
+      }
+
+      return new Promise<T | null>((resolve) => {
+        pendingOps.current.push(async () => {
+          const result = await executeWithRecovery(operation);
+          resolve(result);
+        });
+      });
+    },
+    [state.isOnline, executeWithRecovery]
+  );
+
+  return {
+    ...state,
+    executeWithRecovery,
+    queueWhenOnline,
+  };
+}

--- a/src/hooks/useNetworkRecovery.ts
+++ b/src/hooks/useNetworkRecovery.ts
@@ -32,14 +32,23 @@ export function useNetworkRecovery(options: UseNetworkRecoveryOptions = {}) {
   });
 
   const pendingOps = useRef<Array<() => Promise<unknown>>>([]);
+  const isOnlineRef = useRef(state.isOnline);
+
+  useEffect(() => {
+    isOnlineRef.current = state.isOnline;
+  }, [state.isOnline]);
 
   useEffect(() => {
     const handleOnline = () => {
       setState((prev) => ({ ...prev, isOnline: true }));
 
-      // Flush any pending operations
+      // Flush pending operations individually so one failure doesn't block others
       const ops = pendingOps.current.splice(0);
-      ops.forEach((op) => op());
+      ops.forEach((op) => {
+        op().catch(() => {
+          // Individual operation failures are handled by executeWithRecovery
+        });
+      });
 
       onRecovered?.();
     };
@@ -82,7 +91,7 @@ export function useNetworkRecovery(options: UseNetworkRecoveryOptions = {}) {
 
   const queueWhenOnline = useCallback(
     <T,>(operation: () => Promise<T>): Promise<T | null> => {
-      if (state.isOnline) {
+      if (isOnlineRef.current) {
         return executeWithRecovery(operation);
       }
 
@@ -93,7 +102,7 @@ export function useNetworkRecovery(options: UseNetworkRecoveryOptions = {}) {
         });
       });
     },
-    [state.isOnline, executeWithRecovery]
+    [executeWithRecovery]
   );
 
   return {

--- a/src/lib/errorTracking/client.ts
+++ b/src/lib/errorTracking/client.ts
@@ -234,8 +234,8 @@ const TRACKING_REGISTERED_KEY = '__reflecthub_error_tracking_registered';
 
 export function setupClientErrorTracking(): void {
   if (typeof window === 'undefined') return;
-  if ((window as Record<string, unknown>)[TRACKING_REGISTERED_KEY]) return;
-  (window as Record<string, unknown>)[TRACKING_REGISTERED_KEY] = true;
+  if ((window as unknown as Record<string, unknown>)[TRACKING_REGISTERED_KEY]) return;
+  (window as unknown as Record<string, unknown>)[TRACKING_REGISTERED_KEY] = true;
 
   window.addEventListener('error', (event: ErrorEvent) => {
     errorTrackingClient.capture(event.message, 'uncaught_error', {

--- a/src/lib/errorTracking/client.ts
+++ b/src/lib/errorTracking/client.ts
@@ -41,7 +41,6 @@ class ErrorTrackingClient {
   private sessionId: string = `session_${generateId()}`;
   private userId?: string;
   private flushTimerId: ReturnType<typeof setInterval> | null = null;
-  private lastFlushAt = 0;
   private rateLimitWindowMs = 60_000;
   private rateLimitMax = 30;
   private sentInWindow = 0;
@@ -51,7 +50,7 @@ class ErrorTrackingClient {
     this.loadFromStorage();
     if (typeof window !== 'undefined') {
       this.flushTimerId = setInterval(() => this.flush(), BATCH_INTERVAL_MS);
-      window.addEventListener('beforeunload', () => this.flush());
+      window.addEventListener('beforeunload', () => this.flushSync());
       window.addEventListener('online', () => this.flush());
     }
   }
@@ -93,7 +92,6 @@ class ErrorTrackingClient {
       statusCode: options?.statusCode,
       severity: getSeverity(category, options?.statusCode),
       metadata: options?.metadata,
-      resolved: false,
       createdAt: Date.now(),
     };
 
@@ -138,11 +136,25 @@ class ErrorTrackingClient {
         this.saveToStorage();
       } else {
         this.sentInWindow += batch.length;
-        this.lastFlushAt = Date.now();
       }
     } catch {
       this.queue.unshift(...batch);
       this.saveToStorage();
+    }
+  }
+
+  /** Synchronous send via sendBeacon for use during page unload. */
+  private flushSync(): void {
+    if (this.queue.length === 0 || typeof navigator === 'undefined') return;
+    const batch = this.queue.splice(0, BATCH_SIZE);
+    const payload: ErrorLogBatch = {
+      logs: batch,
+      sessionId: this.sessionId,
+      batchId: generateId(),
+      sentAt: Date.now(),
+    };
+    if (navigator.sendBeacon) {
+      navigator.sendBeacon('/api/logs/errors', JSON.stringify(payload));
     }
   }
 
@@ -194,8 +206,13 @@ class ErrorTrackingClient {
 
 export const errorTrackingClient = ErrorTrackingClient.getInstance();
 
+/** Guard to prevent double-registration of global error handlers. */
+const TRACKING_REGISTERED_KEY = '__reflecthub_error_tracking_registered';
+
 export function setupClientErrorTracking(): void {
   if (typeof window === 'undefined') return;
+  if ((window as Record<string, unknown>)[TRACKING_REGISTERED_KEY]) return;
+  (window as Record<string, unknown>)[TRACKING_REGISTERED_KEY] = true;
 
   window.addEventListener('error', (event: ErrorEvent) => {
     errorTrackingClient.capture(event.message, 'uncaught_error', {

--- a/src/lib/errorTracking/client.ts
+++ b/src/lib/errorTracking/client.ts
@@ -1,0 +1,219 @@
+import type {
+  ErrorCategory,
+  ErrorLogEntry,
+  ErrorLogBatch,
+  ErrorSeverity,
+  ErrorTrackingContext,
+} from '@/types/errorTracking';
+
+const BATCH_SIZE = 10;
+const BATCH_INTERVAL_MS = 30_000;
+const MAX_QUEUE_SIZE = 100;
+const STORAGE_KEY = 'reflecthub_error_queue';
+
+function generateId(): string {
+  return `${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+}
+
+function getSeverity(category: ErrorCategory, statusCode?: number): ErrorSeverity {
+  if (category === 'uncaught_error' || category === 'unhandled_rejection') return 'critical';
+  if (statusCode && statusCode >= 500) return 'critical';
+  if (category === 'server' || category === 'network') return 'error';
+  if (category === 'validation' || category === 'not_found') return 'warning';
+  if (category === 'authentication' || category === 'authorization') return 'warning';
+  if (category === 'offline') return 'info';
+  return 'error';
+}
+
+function buildContext(override?: Partial<ErrorTrackingContext>): ErrorTrackingContext {
+  return {
+    page: typeof window !== 'undefined' ? window.location.pathname : '',
+    url: typeof window !== 'undefined' ? window.location.href : '',
+    userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : '',
+    timestamp: Date.now(),
+    ...override,
+  };
+}
+
+class ErrorTrackingClient {
+  private static instance: ErrorTrackingClient;
+  private queue: ErrorLogEntry[] = [];
+  private sessionId: string = `session_${generateId()}`;
+  private userId?: string;
+  private flushTimerId: ReturnType<typeof setInterval> | null = null;
+  private lastFlushAt = 0;
+  private rateLimitWindowMs = 60_000;
+  private rateLimitMax = 30;
+  private sentInWindow = 0;
+  private windowStartAt = 0;
+
+  private constructor() {
+    this.loadFromStorage();
+    if (typeof window !== 'undefined') {
+      this.flushTimerId = setInterval(() => this.flush(), BATCH_INTERVAL_MS);
+      window.addEventListener('beforeunload', () => this.flush());
+      window.addEventListener('online', () => this.flush());
+    }
+  }
+
+  static getInstance(): ErrorTrackingClient {
+    if (!ErrorTrackingClient.instance) {
+      ErrorTrackingClient.instance = new ErrorTrackingClient();
+    }
+    return ErrorTrackingClient.instance;
+  }
+
+  setUserId(userId: string | undefined): void {
+    this.userId = userId;
+  }
+
+  capture(
+    message: string,
+    category: ErrorCategory,
+    options?: {
+      stack?: string;
+      statusCode?: number;
+      metadata?: Record<string, unknown>;
+      context?: Partial<ErrorTrackingContext>;
+    }
+  ): void {
+    const context = buildContext({
+      userId: this.userId,
+      sessionId: this.sessionId,
+      ...options?.context,
+    });
+
+    const entry: ErrorLogEntry = {
+      id: generateId(),
+      userId: this.userId,
+      errorType: category,
+      message,
+      stack: options?.stack,
+      context,
+      statusCode: options?.statusCode,
+      severity: getSeverity(category, options?.statusCode),
+      metadata: options?.metadata,
+      resolved: false,
+      createdAt: Date.now(),
+    };
+
+    this.enqueue(entry);
+
+    if (this.queue.length >= BATCH_SIZE) {
+      this.flush();
+    }
+  }
+
+  private enqueue(entry: ErrorLogEntry): void {
+    this.queue.push(entry);
+    if (this.queue.length > MAX_QUEUE_SIZE) {
+      this.queue.shift();
+    }
+    this.saveToStorage();
+  }
+
+  async flush(): Promise<void> {
+    if (this.queue.length === 0) return;
+    if (!this.checkRateLimit()) return;
+
+    const batch: ErrorLogEntry[] = this.queue.splice(0, BATCH_SIZE);
+    this.saveToStorage();
+
+    const payload: ErrorLogBatch = {
+      logs: batch,
+      sessionId: this.sessionId,
+      batchId: generateId(),
+      sentAt: Date.now(),
+    };
+
+    try {
+      const res = await fetch('/api/logs/errors', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        this.queue.unshift(...batch);
+        this.saveToStorage();
+      } else {
+        this.sentInWindow += batch.length;
+        this.lastFlushAt = Date.now();
+      }
+    } catch {
+      this.queue.unshift(...batch);
+      this.saveToStorage();
+    }
+  }
+
+  private checkRateLimit(): boolean {
+    const now = Date.now();
+    if (now - this.windowStartAt > this.rateLimitWindowMs) {
+      this.sentInWindow = 0;
+      this.windowStartAt = now;
+    }
+    return this.sentInWindow < this.rateLimitMax;
+  }
+
+  private saveToStorage(): void {
+    try {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(this.queue.slice(-MAX_QUEUE_SIZE)));
+      }
+    } catch {
+      // localStorage may be unavailable
+    }
+  }
+
+  private loadFromStorage(): void {
+    try {
+      if (typeof localStorage !== 'undefined') {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (raw) {
+          const saved = JSON.parse(raw) as ErrorLogEntry[];
+          this.queue = [...saved, ...this.queue].slice(-MAX_QUEUE_SIZE);
+          localStorage.removeItem(STORAGE_KEY);
+        }
+      }
+    } catch {
+      // Ignore corrupt storage data
+    }
+  }
+
+  getQueue(): ErrorLogEntry[] {
+    return [...this.queue];
+  }
+
+  destroy(): void {
+    if (this.flushTimerId) {
+      clearInterval(this.flushTimerId);
+    }
+    this.flush();
+  }
+}
+
+export const errorTrackingClient = ErrorTrackingClient.getInstance();
+
+export function setupClientErrorTracking(): void {
+  if (typeof window === 'undefined') return;
+
+  window.addEventListener('error', (event: ErrorEvent) => {
+    errorTrackingClient.capture(event.message, 'uncaught_error', {
+      stack: event.error?.stack,
+      metadata: {
+        filename: event.filename,
+        lineno: event.lineno,
+        colno: event.colno,
+      },
+    });
+  });
+
+  window.addEventListener('unhandledrejection', (event: PromiseRejectionEvent) => {
+    const message =
+      event.reason instanceof Error ? event.reason.message : String(event.reason);
+    errorTrackingClient.capture(message, 'unhandled_rejection', {
+      stack: event.reason instanceof Error ? event.reason.stack : undefined,
+      metadata: { reason: String(event.reason) },
+    });
+  });
+}

--- a/src/lib/errorTracking/client.ts
+++ b/src/lib/errorTracking/client.ts
@@ -112,9 +112,11 @@ class ErrorTrackingClient {
 
   async flush(): Promise<void> {
     if (this.queue.length === 0) return;
-    if (!this.checkRateLimit()) return;
+    const allowed = this.getRemainingRateLimit();
+    if (allowed <= 0) return;
 
-    const batch: ErrorLogEntry[] = this.queue.splice(0, BATCH_SIZE);
+    const batchSize = Math.min(BATCH_SIZE, allowed);
+    const batch: ErrorLogEntry[] = this.queue.splice(0, batchSize);
     this.saveToStorage();
 
     const payload: ErrorLogBatch = {
@@ -145,26 +147,34 @@ class ErrorTrackingClient {
 
   /** Synchronous send via sendBeacon for use during page unload. */
   private flushSync(): void {
-    if (this.queue.length === 0 || typeof navigator === 'undefined') return;
-    const batch = this.queue.splice(0, BATCH_SIZE);
+    if (
+      this.queue.length === 0 ||
+      typeof navigator === 'undefined' ||
+      !navigator.sendBeacon
+    ) {
+      return;
+    }
+    const batch = this.queue.slice(0, BATCH_SIZE);
     const payload: ErrorLogBatch = {
       logs: batch,
       sessionId: this.sessionId,
       batchId: generateId(),
       sentAt: Date.now(),
     };
-    if (navigator.sendBeacon) {
-      navigator.sendBeacon('/api/logs/errors', JSON.stringify(payload));
+    const sent = navigator.sendBeacon('/api/logs/errors', JSON.stringify(payload));
+    if (sent) {
+      this.queue.splice(0, batch.length);
+      this.saveToStorage();
     }
   }
 
-  private checkRateLimit(): boolean {
+  private getRemainingRateLimit(): number {
     const now = Date.now();
     if (now - this.windowStartAt > this.rateLimitWindowMs) {
       this.sentInWindow = 0;
       this.windowStartAt = now;
     }
-    return this.sentInWindow < this.rateLimitMax;
+    return Math.max(0, this.rateLimitMax - this.sentInWindow);
   }
 
   private saveToStorage(): void {

--- a/src/lib/errorTracking/client.ts
+++ b/src/lib/errorTracking/client.ts
@@ -28,7 +28,11 @@ function getSeverity(category: ErrorCategory, statusCode?: number): ErrorSeverit
 function buildContext(override?: Partial<ErrorTrackingContext>): ErrorTrackingContext {
   return {
     page: typeof window !== 'undefined' ? window.location.pathname : '',
-    url: typeof window !== 'undefined' ? window.location.href : '',
+    // Use origin+pathname to avoid capturing sensitive query params / hash fragments by default.
+    url:
+      typeof window !== 'undefined'
+        ? `${window.location.origin}${window.location.pathname}`
+        : '',
     userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : '',
     timestamp: Date.now(),
     ...override,
@@ -45,6 +49,7 @@ class ErrorTrackingClient {
   private rateLimitMax = 30;
   private sentInWindow = 0;
   private windowStartAt = 0;
+  private isFlushing = false;
 
   private constructor() {
     this.loadFromStorage();
@@ -111,22 +116,28 @@ class ErrorTrackingClient {
   }
 
   async flush(): Promise<void> {
-    if (this.queue.length === 0) return;
-    const allowed = this.getRemainingRateLimit();
-    if (allowed <= 0) return;
-
-    const batchSize = Math.min(BATCH_SIZE, allowed);
-    const batch: ErrorLogEntry[] = this.queue.splice(0, batchSize);
-    this.saveToStorage();
-
-    const payload: ErrorLogBatch = {
-      logs: batch,
-      sessionId: this.sessionId,
-      batchId: generateId(),
-      sentAt: Date.now(),
-    };
-
+    if (this.isFlushing || this.queue.length === 0) return;
+    this.isFlushing = true;
+    let batch: ErrorLogEntry[] = [];
     try {
+      const allowed = this.getRemainingRateLimit();
+      if (allowed <= 0) return;
+
+      const batchSize = Math.min(BATCH_SIZE, allowed, this.queue.length);
+      if (batchSize <= 0) return;
+
+      // Reserve quota before the async boundary so concurrent calls see it.
+      this.sentInWindow += batchSize;
+      batch = this.queue.splice(0, batchSize);
+      this.saveToStorage();
+
+      const payload: ErrorLogBatch = {
+        logs: batch,
+        sessionId: this.sessionId,
+        batchId: generateId(),
+        sentAt: Date.now(),
+      };
+
       const res = await fetch('/api/logs/errors', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -134,14 +145,16 @@ class ErrorTrackingClient {
       });
 
       if (!res.ok) {
+        this.sentInWindow = Math.max(0, this.sentInWindow - batch.length);
         this.queue.unshift(...batch);
         this.saveToStorage();
-      } else {
-        this.sentInWindow += batch.length;
       }
     } catch {
+      this.sentInWindow = Math.max(0, this.sentInWindow - batch.length);
       this.queue.unshift(...batch);
       this.saveToStorage();
+    } finally {
+      this.isFlushing = false;
     }
   }
 

--- a/src/services/errorLoggingService.test.ts
+++ b/src/services/errorLoggingService.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { setupErrorHandling } from './errorLoggingService';
+
+describe('setupErrorHandling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not throw when called in browser context', () => {
+    expect(() => setupErrorHandling()).not.toThrow();
+  });
+
+  it('registers global error handlers', () => {
+    const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
+    setupErrorHandling();
+
+    const registeredEvents = addEventListenerSpy.mock.calls.map(([event]) => event);
+    expect(registeredEvents).toContain('error');
+    expect(registeredEvents).toContain('unhandledrejection');
+    expect(registeredEvents).toContain('beforeunload');
+  });
+});
+
+describe('ErrorLoggingService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('logs an error to the queue', async () => {
+    const { errorLoggingService } = await import('./errorLoggingService');
+    const initialLength = errorLoggingService.getQueue().length;
+
+    errorLoggingService.log('テストエラー', 'network', undefined, { page: '/test' });
+
+    expect(errorLoggingService.getQueue().length).toBeGreaterThanOrEqual(initialLength);
+  });
+
+  it('clears the queue', async () => {
+    const { errorLoggingService } = await import('./errorLoggingService');
+    errorLoggingService.log('エラー1', 'unknown');
+    errorLoggingService.clearQueue();
+    expect(errorLoggingService.getQueue()).toHaveLength(0);
+  });
+
+  it('sends logs to API on flush', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { errorLoggingService } = await import('./errorLoggingService');
+    errorLoggingService.log('送信テスト', 'server');
+    await errorLoggingService.flush();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/logs/errors',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('restores queue when flush fails', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('Network error'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { errorLoggingService } = await import('./errorLoggingService');
+    errorLoggingService.clearQueue();
+    errorLoggingService.log('失敗テスト', 'network');
+
+    const before = errorLoggingService.getQueue().length;
+    await errorLoggingService.flush();
+
+    expect(errorLoggingService.getQueue().length).toBeGreaterThanOrEqual(before);
+  });
+});

--- a/src/services/errorLoggingService.test.ts
+++ b/src/services/errorLoggingService.test.ts
@@ -1,13 +1,18 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { setupErrorHandling } from './errorLoggingService';
 
+const SETUP_KEY = '__reflecthub_error_handling_registered';
+
 describe('setupErrorHandling', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset the idempotency guard so each test starts fresh
+    delete (window as unknown as Record<string, unknown>)[SETUP_KEY];
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    delete (window as unknown as Record<string, unknown>)[SETUP_KEY];
   });
 
   it('does not throw when called in browser context', () => {

--- a/src/services/errorLoggingService.test.ts
+++ b/src/services/errorLoggingService.test.ts
@@ -37,11 +37,11 @@ describe('ErrorLoggingService', () => {
 
   it('logs an error to the queue', async () => {
     const { errorLoggingService } = await import('./errorLoggingService');
-    const initialLength = errorLoggingService.getQueue().length;
+    errorLoggingService.clearQueue();
 
     errorLoggingService.log('テストエラー', 'network', undefined, { page: '/test' });
 
-    expect(errorLoggingService.getQueue().length).toBeGreaterThanOrEqual(initialLength);
+    expect(errorLoggingService.getQueue()).toHaveLength(1);
   });
 
   it('clears the queue', async () => {

--- a/src/services/errorLoggingService.ts
+++ b/src/services/errorLoggingService.ts
@@ -108,8 +108,8 @@ const SETUP_KEY = '__reflecthub_error_handling_registered';
 
 export function setupErrorHandling(): void {
   if (typeof window === 'undefined') return;
-  if ((window as Record<string, unknown>)[SETUP_KEY]) return;
-  (window as Record<string, unknown>)[SETUP_KEY] = true;
+  if ((window as unknown as Record<string, unknown>)[SETUP_KEY]) return;
+  (window as unknown as Record<string, unknown>)[SETUP_KEY] = true;
 
   window.addEventListener('error', (event: ErrorEvent) => {
     errorLoggingService.log(event.message, 'uncaught_error', event.error?.stack, {

--- a/src/services/errorLoggingService.ts
+++ b/src/services/errorLoggingService.ts
@@ -1,6 +1,3 @@
-import { errorTrackingClient } from '@/lib/errorTracking/client';
-import type { ErrorCategory } from '@/types/errorTracking';
-
 export interface ErrorLog {
   id: string;
   timestamp: number;
@@ -40,10 +37,6 @@ class ErrorLoggingService {
     return ErrorLoggingService.instance;
   }
 
-  setUserId(userId: string | undefined): void {
-    errorTrackingClient.setUserId(userId);
-  }
-
   log(
     message: string,
     type: string,
@@ -70,13 +63,6 @@ class ErrorLoggingService {
     if (this.queue.length >= this.maxQueueSize) {
       this.flush();
     }
-
-    // Also forward to the new tracking client
-    errorTrackingClient.capture(message, type as ErrorCategory, {
-      stack,
-      statusCode,
-      metadata,
-    });
   }
 
   async flush(): Promise<void> {
@@ -89,7 +75,7 @@ class ErrorLoggingService {
       await fetch('/api/logs/errors', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ logs: logsToSend }),
+        body: JSON.stringify({ logs: logsToSend, sessionId: this.sessionId }),
       });
     } catch (error) {
       this.queue = [...logsToSend, ...this.queue];
@@ -117,8 +103,13 @@ class ErrorLoggingService {
 
 export const errorLoggingService = ErrorLoggingService.getInstance();
 
+/** Guard to prevent double-registration of global error handlers. */
+const SETUP_KEY = '__reflecthub_error_handling_registered';
+
 export function setupErrorHandling(): void {
   if (typeof window === 'undefined') return;
+  if ((window as Record<string, unknown>)[SETUP_KEY]) return;
+  (window as Record<string, unknown>)[SETUP_KEY] = true;
 
   window.addEventListener('error', (event: ErrorEvent) => {
     errorLoggingService.log(event.message, 'uncaught_error', event.error?.stack, {

--- a/src/services/errorLoggingService.ts
+++ b/src/services/errorLoggingService.ts
@@ -1,7 +1,5 @@
-/**
- * Error Logging Service
- * Collects and sends error information to server
- */
+import { errorTrackingClient } from '@/lib/errorTracking/client';
+import type { ErrorCategory } from '@/types/errorTracking';
 
 export interface ErrorLog {
   id: string;
@@ -18,27 +16,19 @@ export interface ErrorLog {
   metadata?: Record<string, unknown>;
 }
 
-/**
- * Error Logging Service for collecting and sending error logs
- */
 class ErrorLoggingService {
   private static instance: ErrorLoggingService;
   private queue: ErrorLog[] = [];
   private maxQueueSize = 50;
-  private flushInterval = 30000; // 30 seconds
-  private flushTimeoutId: NodeJS.Timeout | null = null;
+  private flushInterval = 30000;
+  private flushTimeoutId: ReturnType<typeof setInterval> | null = null;
   private sessionId: string;
 
   private constructor() {
-    this.sessionId = this.generateSessionId();
+    this.sessionId = `session_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
 
-    // Set up periodic flush
     if (typeof window !== 'undefined') {
       this.flushTimeoutId = setInterval(() => this.flush(), this.flushInterval);
-    }
-
-    // Flush on page unload
-    if (typeof window !== 'undefined') {
       window.addEventListener('beforeunload', () => this.flush());
     }
   }
@@ -50,16 +40,10 @@ class ErrorLoggingService {
     return ErrorLoggingService.instance;
   }
 
-  /**
-   * Generate a unique session ID
-   */
-  private generateSessionId(): string {
-    return `session_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+  setUserId(userId: string | undefined): void {
+    errorTrackingClient.setUserId(userId);
   }
 
-  /**
-   * Add error log to queue
-   */
   log(
     message: string,
     type: string,
@@ -68,7 +52,7 @@ class ErrorLoggingService {
     statusCode?: number
   ): void {
     const errorLog: ErrorLog = {
-      id: `error_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+      id: `error_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`,
       timestamp: Date.now(),
       message,
       stack,
@@ -83,59 +67,46 @@ class ErrorLoggingService {
 
     this.queue.push(errorLog);
 
-    // Flush if queue is getting full
     if (this.queue.length >= this.maxQueueSize) {
       this.flush();
     }
+
+    // Also forward to the new tracking client
+    errorTrackingClient.capture(message, type as ErrorCategory, {
+      stack,
+      statusCode,
+      metadata,
+    });
   }
 
-  /**
-   * Send queued logs to server
-   */
   async flush(): Promise<void> {
-    if (this.queue.length === 0) {
-      return;
-    }
+    if (this.queue.length === 0) return;
 
     const logsToSend = [...this.queue];
     this.queue = [];
 
     try {
-      await fetch('/api/logs', {
+      await fetch('/api/logs/errors', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ logs: logsToSend }),
       });
     } catch (error) {
-      // If sending fails, put logs back in queue
       this.queue = [...logsToSend, ...this.queue];
-
-      // Log to console in development
       if (process.env.NODE_ENV === 'development') {
         console.error('Failed to send error logs:', error);
       }
     }
   }
 
-  /**
-   * Get current queue
-   */
   getQueue(): ErrorLog[] {
     return [...this.queue];
   }
 
-  /**
-   * Clear queue
-   */
   clearQueue(): void {
     this.queue = [];
   }
 
-  /**
-   * Destroy service and clean up
-   */
   destroy(): void {
     if (this.flushTimeoutId) {
       clearInterval(this.flushTimeoutId);
@@ -146,29 +117,17 @@ class ErrorLoggingService {
 
 export const errorLoggingService = ErrorLoggingService.getInstance();
 
-/**
- * Global error handler setup
- */
 export function setupErrorHandling(): void {
-  if (typeof window === 'undefined') {
-    return;
-  }
+  if (typeof window === 'undefined') return;
 
-  // Handle uncaught errors
   window.addEventListener('error', (event: ErrorEvent) => {
-    errorLoggingService.log(
-      event.message,
-      'uncaught_error',
-      event.error?.stack,
-      {
-        filename: event.filename,
-        lineno: event.lineno,
-        colno: event.colno,
-      }
-    );
+    errorLoggingService.log(event.message, 'uncaught_error', event.error?.stack, {
+      filename: event.filename,
+      lineno: event.lineno,
+      colno: event.colno,
+    });
   });
 
-  // Handle unhandled promise rejections
   window.addEventListener('unhandledrejection', (event: PromiseRejectionEvent) => {
     const message =
       event.reason instanceof Error ? event.reason.message : String(event.reason);
@@ -177,13 +136,10 @@ export function setupErrorHandling(): void {
       message,
       'unhandled_rejection',
       event.reason instanceof Error ? event.reason.stack : undefined,
-      {
-        reason: event.reason,
-      }
+      { reason: event.reason }
     );
   });
 
-  // Flush logs before page unload
   window.addEventListener('beforeunload', () => {
     errorLoggingService.flush();
   });

--- a/src/types/errorTracking.ts
+++ b/src/types/errorTracking.ts
@@ -1,0 +1,64 @@
+export type ErrorSeverity = 'critical' | 'error' | 'warning' | 'info';
+
+export type ErrorCategory =
+  | 'uncaught_error'
+  | 'unhandled_rejection'
+  | 'network'
+  | 'offline'
+  | 'validation'
+  | 'authentication'
+  | 'authorization'
+  | 'not_found'
+  | 'server'
+  | 'unknown';
+
+export interface ErrorTrackingContext {
+  page: string;
+  action?: string;
+  userId?: string;
+  sessionId?: string;
+  timestamp: number;
+  userAgent?: string;
+  url: string;
+}
+
+export interface ErrorLogEntry {
+  id: string;
+  userId?: string;
+  errorType: ErrorCategory;
+  message: string;
+  stack?: string;
+  context: ErrorTrackingContext;
+  statusCode?: number;
+  severity: ErrorSeverity;
+  metadata?: Record<string, unknown>;
+  resolved: boolean;
+  resolvedAt?: number;
+  resolvedBy?: string;
+  createdAt: number;
+}
+
+export interface ErrorLogBatch {
+  logs: ErrorLogEntry[];
+  sessionId: string;
+  batchId: string;
+  sentAt: number;
+}
+
+export interface ErrorLogApiRequest {
+  logs: ErrorLogEntry[];
+  sessionId: string;
+}
+
+export interface ErrorLogApiResponse {
+  success: boolean;
+  received: number;
+  message?: string;
+}
+
+export interface ErrorLogListResponse {
+  logs: ErrorLogEntry[];
+  total: number;
+  page: number;
+  perPage: number;
+}

--- a/src/types/errorTracking.ts
+++ b/src/types/errorTracking.ts
@@ -22,6 +22,7 @@ export interface ErrorTrackingContext {
   url: string;
 }
 
+/** Ingest DTO — sent from the client to the API. */
 export interface ErrorLogEntry {
   id: string;
   userId?: string;
@@ -32,10 +33,14 @@ export interface ErrorLogEntry {
   statusCode?: number;
   severity: ErrorSeverity;
   metadata?: Record<string, unknown>;
+  createdAt: number;
+}
+
+/** Persisted record — returned by the API after storage. */
+export interface PersistedErrorLog extends ErrorLogEntry {
   resolved: boolean;
   resolvedAt?: number;
   resolvedBy?: string;
-  createdAt: number;
 }
 
 export interface ErrorLogBatch {
@@ -57,7 +62,7 @@ export interface ErrorLogApiResponse {
 }
 
 export interface ErrorLogListResponse {
-  logs: ErrorLogEntry[];
+  logs: PersistedErrorLog[];
   total: number;
   page: number;
   perPage: number;

--- a/src/utils/errorHandler.test.ts
+++ b/src/utils/errorHandler.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  ErrorType,
+  createAppError,
+  getErrorMessage,
+  handleFetchError,
+  retryOperation,
+  retryWithNetworkRecovery,
+  waitForOnline,
+} from './errorHandler';
+
+describe('getErrorMessage', () => {
+  it('returns Japanese message for NETWORK error', () => {
+    const error = { type: ErrorType.NETWORK, message: '', timestamp: 0 };
+    expect(getErrorMessage(error)).toContain('ネットワーク');
+  });
+
+  it('returns Japanese message for OFFLINE error', () => {
+    const error = { type: ErrorType.OFFLINE, message: '', timestamp: 0 };
+    expect(getErrorMessage(error)).toContain('オフライン');
+  });
+
+  it('returns Japanese message for SERVER error', () => {
+    const error = { type: ErrorType.SERVER, message: '', timestamp: 0 };
+    expect(getErrorMessage(error)).toContain('サーバーエラー');
+  });
+
+  it('returns Japanese message for AUTHENTICATION error', () => {
+    const error = { type: ErrorType.AUTHENTICATION, message: '', timestamp: 0 };
+    expect(getErrorMessage(error)).toContain('ログイン');
+  });
+
+  it('returns Japanese message for VALIDATION error', () => {
+    const error = { type: ErrorType.VALIDATION, message: '', timestamp: 0 };
+    expect(getErrorMessage(error)).toContain('入力');
+  });
+
+  it('returns custom message for UNKNOWN error when message is set', () => {
+    const error = { type: ErrorType.UNKNOWN, message: 'カスタムエラー', timestamp: 0 };
+    expect(getErrorMessage(error)).toBe('カスタムエラー');
+  });
+});
+
+describe('createAppError', () => {
+  it('classifies 401 as AUTHENTICATION', () => {
+    const err = createAppError(new Error('Unauthorized'), 401);
+    expect(err.type).toBe(ErrorType.AUTHENTICATION);
+    expect(err.statusCode).toBe(401);
+  });
+
+  it('classifies 403 as AUTHORIZATION', () => {
+    const err = createAppError(new Error('Forbidden'), 403);
+    expect(err.type).toBe(ErrorType.AUTHORIZATION);
+  });
+
+  it('classifies 404 as NOT_FOUND', () => {
+    const err = createAppError(new Error('Not Found'), 404);
+    expect(err.type).toBe(ErrorType.NOT_FOUND);
+  });
+
+  it('classifies 500 as SERVER', () => {
+    const err = createAppError(new Error('Server Error'), 500);
+    expect(err.type).toBe(ErrorType.SERVER);
+  });
+
+  it('classifies network error message as NETWORK', () => {
+    const err = createAppError(new Error('fetch failed'));
+    expect(err.type).toBe(ErrorType.NETWORK);
+  });
+
+  it('uses customMessage when provided', () => {
+    const err = createAppError(new Error('original'), undefined, 'カスタムメッセージ');
+    expect(err.message).toBe('カスタムメッセージ');
+  });
+
+  it('includes timestamp', () => {
+    const before = Date.now();
+    const err = createAppError(new Error('test'));
+    expect(err.timestamp).toBeGreaterThanOrEqual(before);
+  });
+});
+
+describe('handleFetchError', () => {
+  it('extracts message from JSON response', async () => {
+    const response = new Response(JSON.stringify({ error: 'Bad request' }), {
+      status: 400,
+    });
+    const err = await handleFetchError(response);
+    expect(err.message).toBe('Bad request');
+    expect(err.statusCode).toBe(400);
+  });
+
+  it('uses customMessage when provided', async () => {
+    const response = new Response(JSON.stringify({}), { status: 500 });
+    const err = await handleFetchError(response, '上書きメッセージ');
+    expect(err.message).toBe('上書きメッセージ');
+  });
+});
+
+describe('retryOperation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('succeeds on first attempt', async () => {
+    const op = vi.fn().mockResolvedValue('ok');
+    const result = await retryOperation(op, 3, 100);
+    expect(result).toBe('ok');
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries and succeeds on second attempt', async () => {
+    let calls = 0;
+    const op = vi.fn().mockImplementation(() => {
+      calls++;
+      if (calls < 2) return Promise.reject(new Error('fail'));
+      return Promise.resolve('success');
+    });
+
+    const promise = retryOperation(op, 3, 1000);
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe('success');
+    expect(op).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws after exhausting retries', async () => {
+    const op = vi.fn().mockRejectedValue(new Error('always fails'));
+
+    const promise = retryOperation(op, 3, 1000);
+    await vi.runAllTimersAsync();
+
+    await expect(promise).rejects.toThrow('always fails');
+    expect(op).toHaveBeenCalledTimes(3);
+  });
+
+  it('uses exponential backoff delays (1s → 2s → 4s)', async () => {
+    const delays: number[] = [];
+    const op = vi.fn().mockRejectedValue(new Error('fail'));
+
+    const originalSetTimeout = globalThis.setTimeout;
+    const setTimeoutSpy = vi
+      .spyOn(globalThis, 'setTimeout')
+      .mockImplementation((fn: TimerHandler, delay?: number) => {
+        if (typeof delay === 'number') delays.push(delay);
+        return originalSetTimeout(fn as () => void, 0);
+      });
+
+    const promise = retryOperation(op, 3, 1000);
+    await vi.runAllTimersAsync();
+
+    try {
+      await promise;
+    } catch {
+      // expected
+    }
+
+    setTimeoutSpy.mockRestore();
+
+    expect(delays[0]).toBe(1000);
+    expect(delays[1]).toBe(2000);
+  });
+});
+
+describe('waitForOnline', () => {
+  it('resolves immediately when online', async () => {
+    Object.defineProperty(window.navigator, 'onLine', {
+      value: true,
+      configurable: true,
+    });
+
+    await expect(waitForOnline()).resolves.toBeUndefined();
+  });
+
+  it('resolves when online event fires', async () => {
+    Object.defineProperty(window.navigator, 'onLine', {
+      value: false,
+      configurable: true,
+    });
+
+    const promise = waitForOnline();
+    window.dispatchEvent(new Event('online'));
+
+    await expect(promise).resolves.toBeUndefined();
+
+    Object.defineProperty(window.navigator, 'onLine', {
+      value: true,
+      configurable: true,
+    });
+  });
+});
+
+describe('retryWithNetworkRecovery', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.defineProperty(window.navigator, 'onLine', {
+      value: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('succeeds immediately when online', async () => {
+    const op = vi.fn().mockResolvedValue('ok');
+    const result = await retryWithNetworkRecovery(op, 3, 1000);
+    expect(result).toBe('ok');
+  });
+
+  it('does not retry on non-recoverable errors', async () => {
+    const op = vi.fn().mockRejectedValue(new Error('Validation failed'));
+    const promise = retryWithNetworkRecovery(op, 3, 100);
+    await vi.runAllTimersAsync();
+    await expect(promise).rejects.toThrow();
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/errorHandler.ts
+++ b/src/utils/errorHandler.ts
@@ -18,6 +18,8 @@ export interface AppError {
   isDev?: boolean;
 }
 
+const SESSION_ID = `session_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+
 class ErrorLogger {
   private static instance: ErrorLogger;
   private logs: AppError[] = [];
@@ -54,6 +56,7 @@ class ErrorLogger {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
+          sessionId: SESSION_ID,
           logs: [
             {
               id: `err_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`,
@@ -66,7 +69,6 @@ class ErrorLogger {
                 url: typeof window !== 'undefined' ? window.location.href : '',
                 timestamp: error.timestamp,
               },
-              resolved: false,
               createdAt: error.timestamp,
             },
           ],
@@ -219,22 +221,33 @@ export async function retryOperation<T>(
 }
 
 /**
- * Execute an operation once the browser is back online.
- * Resolves immediately if already online; otherwise waits for the 'online' event.
+ * Wait until the browser is online.
+ * Resolves immediately if already online, otherwise waits for the 'online' event.
+ * An optional timeoutMs can be provided to avoid waiting indefinitely.
  */
-export function waitForOnline(): Promise<void> {
+export function waitForOnline(timeoutMs?: number): Promise<void> {
   return new Promise((resolve) => {
     if (typeof window === 'undefined' || window.navigator.onLine) {
       resolve();
       return;
     }
 
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
     const handler = () => {
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
       window.removeEventListener('online', handler);
       resolve();
     };
 
     window.addEventListener('online', handler);
+
+    if (timeoutMs !== undefined && timeoutMs > 0) {
+      timeoutId = setTimeout(() => {
+        window.removeEventListener('online', handler);
+        resolve();
+      }, timeoutMs);
+    }
   });
 }
 

--- a/src/utils/errorHandler.ts
+++ b/src/utils/errorHandler.ts
@@ -1,8 +1,3 @@
-/**
- * Error handling utility
- * Provides unified error handling across the application
- */
-
 export enum ErrorType {
   NETWORK = 'NETWORK',
   OFFLINE = 'OFFLINE',
@@ -23,9 +18,6 @@ export interface AppError {
   isDev?: boolean;
 }
 
-/**
- * Error logger for collecting error information
- */
 class ErrorLogger {
   private static instance: ErrorLogger;
   private logs: AppError[] = [];
@@ -43,30 +35,42 @@ class ErrorLogger {
   log(error: AppError): void {
     this.logs.push(error);
 
-    // Keep only the latest logs
     if (this.logs.length > this.maxLogs) {
       this.logs.shift();
     }
 
-    // Log to console in development
     if (typeof window !== 'undefined' && process.env.NODE_ENV === 'development') {
       console.error('[AppError]', error);
     }
 
-    // Send to external service in production (optional)
     if (typeof window !== 'undefined' && process.env.NODE_ENV === 'production') {
       this.sendToServer(error);
     }
   }
 
   private sendToServer(error: AppError): void {
-    // TODO: Implement server-side error logging
-    // Example: Send to Sentry, LogRocket, or custom endpoint
     try {
       fetch('/api/logs/errors', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(error),
+        body: JSON.stringify({
+          logs: [
+            {
+              id: `err_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`,
+              errorType: error.type.toLowerCase(),
+              message: error.message,
+              statusCode: error.statusCode,
+              severity: error.type === ErrorType.SERVER ? 'critical' : 'error',
+              context: {
+                page: typeof window !== 'undefined' ? window.location.pathname : '',
+                url: typeof window !== 'undefined' ? window.location.href : '',
+                timestamp: error.timestamp,
+              },
+              resolved: false,
+              createdAt: error.timestamp,
+            },
+          ],
+        }),
       }).catch(() => {
         // Silently fail if logging fails
       });
@@ -84,16 +88,11 @@ class ErrorLogger {
   }
 }
 
-/**
- * Classify error type based on error object or status code
- */
 function classifyError(error: unknown, statusCode?: number): ErrorType {
-  // Check for offline
   if (typeof window !== 'undefined' && !window.navigator.onLine) {
     return ErrorType.OFFLINE;
   }
 
-  // Check status code
   if (statusCode) {
     if (statusCode === 401) return ErrorType.AUTHENTICATION;
     if (statusCode === 403) return ErrorType.AUTHORIZATION;
@@ -102,7 +101,6 @@ function classifyError(error: unknown, statusCode?: number): ErrorType {
     if (statusCode >= 400) return ErrorType.VALIDATION;
   }
 
-  // Check error message
   if (error instanceof Error) {
     const message = error.message.toLowerCase();
     if (
@@ -124,9 +122,6 @@ function classifyError(error: unknown, statusCode?: number): ErrorType {
   return ErrorType.UNKNOWN;
 }
 
-/**
- * Get user-friendly error message
- */
 export function getErrorMessage(error: AppError): string {
   switch (error.type) {
     case ErrorType.NETWORK:
@@ -149,9 +144,6 @@ export function getErrorMessage(error: AppError): string {
   }
 }
 
-/**
- * Create an AppError from an unknown error source
- */
 export function createAppError(
   error: unknown,
   statusCode?: number,
@@ -175,15 +167,11 @@ export function createAppError(
     isDev: process.env.NODE_ENV === 'development',
   };
 
-  // Log the error
   ErrorLogger.getInstance().log(appError);
 
   return appError;
 }
 
-/**
- * Handle network request errors
- */
 export async function handleFetchError(
   response: Response,
   customMessage?: string
@@ -205,12 +193,12 @@ export async function handleFetchError(
 }
 
 /**
- * Retry logic for failed operations
+ * Retry with exponential backoff: 1s → 2s → 4s
  */
 export async function retryOperation<T>(
   operation: () => Promise<T>,
   maxRetries: number = 3,
-  delayMs: number = 1000
+  initialDelayMs: number = 1000
 ): Promise<T> {
   let lastError: Error | undefined;
 
@@ -221,8 +209,7 @@ export async function retryOperation<T>(
       lastError = error instanceof Error ? error : new Error(String(error));
 
       if (attempt < maxRetries) {
-        // Exponential backoff
-        const delay = delayMs * Math.pow(2, attempt - 1);
+        const delay = initialDelayMs * Math.pow(2, attempt - 1);
         await new Promise((resolve) => setTimeout(resolve, delay));
       }
     }
@@ -232,6 +219,63 @@ export async function retryOperation<T>(
 }
 
 /**
- * Export error logger instance
+ * Execute an operation once the browser is back online.
+ * Resolves immediately if already online; otherwise waits for the 'online' event.
  */
+export function waitForOnline(): Promise<void> {
+  return new Promise((resolve) => {
+    if (typeof window === 'undefined' || window.navigator.onLine) {
+      resolve();
+      return;
+    }
+
+    const handler = () => {
+      window.removeEventListener('online', handler);
+      resolve();
+    };
+
+    window.addEventListener('online', handler);
+  });
+}
+
+/**
+ * Retry an operation, automatically waiting for network connectivity if offline.
+ * Uses exponential backoff (1s → 2s → 4s) for network/offline errors.
+ */
+export async function retryWithNetworkRecovery<T>(
+  operation: () => Promise<T>,
+  maxRetries: number = 3,
+  initialDelayMs: number = 1000
+): Promise<T> {
+  let lastError: Error | undefined;
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      if (typeof window !== 'undefined' && !window.navigator.onLine) {
+        await waitForOnline();
+      }
+      return await operation();
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      const errorType = classifyError(error);
+
+      const isRecoverable =
+        errorType === ErrorType.NETWORK ||
+        errorType === ErrorType.OFFLINE ||
+        errorType === ErrorType.SERVER;
+
+      if (!isRecoverable || attempt >= maxRetries) break;
+
+      if (errorType === ErrorType.OFFLINE) {
+        await waitForOnline();
+      } else {
+        const delay = initialDelayMs * Math.pow(2, attempt - 1);
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    }
+  }
+
+  throw lastError || new Error('Operation failed');
+}
+
 export const errorLogger = ErrorLogger.getInstance();


### PR DESCRIPTION
## 概要

Issue #68 の実装です。Phase 1 の基本的なエラーハンドリングを強化し、エラーログ記録・分析機構と自動回復機能を追加しました。

## 実装内容

### エラーログ記録システム

- **`src/types/errorTracking.ts`** — 型定義
  - `ErrorLogEntry`, `ErrorLogBatch`, `ErrorTrackingContext`, `ErrorSeverity`, `ErrorCategory` など

- **`src/lib/errorTracking/client.ts`** — フロントエンド エラー追跡クライアント
  - コンテキスト自動収集（ページ、URL、userAgent、sessionId）
  - バッチ送信（10件毎 or 30秒ごとに自動フラッシュ）
  - レート制限（60秒間 最大30件）
  - localStorage バックアップ（送信失敗時の永続化）
  - グローバルエラーハンドラー（`uncaught_error`, `unhandled_rejection`）

- **`src/app/api/logs/errors/route.ts`** — エラーログ API
  - `POST /api/logs/errors` — エラーログ受信・Supabase `error_logs` テーブルへ保存
  - `GET /api/logs/errors?user_id=:id` — ページネーション付きログ一覧取得（認証・認可チェック付き）

- **`src/services/errorLoggingService.ts`** — 既存サービス更新
  - `setUserId()` メソッド追加（userId 追跡）
  - 新しい `errorTrackingClient` との統合

### 自動回復機構の強化

- **`src/utils/errorHandler.ts`** — 拡張
  - `retryOperation()`: 指数バックオフ改善（初期値 1s → 2s → 4s）
  - `waitForOnline()`: オンライン復帰まで待機
  - `retryWithNetworkRecovery()`: オフライン検出・自動復帰後リトライ（NETWORK/OFFLINE/SERVER エラーのみ）

- **`src/hooks/useNetworkRecovery.ts`** — ネットワーク回復 React フック
  - `isOnline` / `isRetrying` / `lastError` 状態管理
  - `executeWithRecovery()`: リトライ付きで操作実行
  - `queueWhenOnline()`: オフライン中は操作をキューイング、復帰後自動実行

### Graceful Degradation

- **`src/components/common/ServiceUnavailable.tsx`** — フォールバック UI
  - サービス利用不可時に表示する日本語コンポーネント
  - 再試行ボタン付き

### テスト

- `src/utils/errorHandler.test.ts` — エラー分類・リトライ・バックオフ・オフライン回復テスト
- `src/services/errorLoggingService.test.ts` — ログ記録・フラッシュ・キュー管理テスト
- `src/app/api/logs/errors/route.test.ts` — POST/GET エンドポイントテスト（認証・認可含む）

## チェックリスト

- [x] エラーログテーブル対応 API 実装完了
- [x] フロントエンド エラー追跡実装
- [x] エラーログ API 実装完了（POST/GET）
- [x] 自動回復機構（指数バックオフ・オフライン復帰）
- [x] ネットワークエラー自動回復フック
- [x] Graceful degradation フォールバック UI
- [x] エラーメッセージ日本語化（既存実装を維持・拡充）
- [x] テスト実装

## 関連 Issue

Closes #68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client-side error tracking with persistent queueing, batched delivery, beacon-on-unload, and global handlers
  * Network-recovery hook that queues operations, auto-retries, and flushes when online
  * API endpoints to submit and retrieve paginated per-user error logs
  * Service-unavailable UI component with optional retry
  * New type definitions for error tracking payloads

* **Bug Fixes / Improvements**
  * Include session identifiers in log submissions; tightened retry/backoff, pagination and flush behavior; deduped global handler setup

* **Tests**
  * Added tests covering ingestion endpoints, client logging/flush, retry helpers, and recovery logic
<!-- end of auto-generated comment: release notes by coderabbit.ai -->