### PR TITLE
[Phase 2.5] Web プッシュ基盤構築 & テスト体制確立 - データモデル, テストカバレッジ

### DIFF
--- a/database/push-subscriptions-and-preferences.sql
+++ b/database/push-subscriptions-and-preferences.sql
@@ -45,6 +45,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+DROP TRIGGER IF EXISTS push_subscriptions_updated_at ON push_subscriptions;
 CREATE TRIGGER push_subscriptions_updated_at
   BEFORE UPDATE ON push_subscriptions
   FOR EACH ROW EXECUTE FUNCTION update_push_subscriptions_updated_at();
@@ -94,6 +95,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+DROP TRIGGER IF EXISTS user_preferences_updated_at ON user_preferences;
 CREATE TRIGGER user_preferences_updated_at
   BEFORE UPDATE ON user_preferences
   FOR EACH ROW EXECUTE FUNCTION update_user_preferences_updated_at();

--- a/database/push-subscriptions-and-preferences.sql
+++ b/database/push-subscriptions-and-preferences.sql
@@ -1,0 +1,99 @@
+-- Push Subscriptions テーブル
+CREATE TABLE IF NOT EXISTS push_subscriptions (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  endpoint TEXT NOT NULL,
+  p256dh TEXT NOT NULL,
+  auth TEXT NOT NULL,
+  user_agent TEXT,
+  browser TEXT,
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- endpoint はユーザーごとに一意
+CREATE UNIQUE INDEX IF NOT EXISTS push_subscriptions_user_endpoint_idx
+  ON push_subscriptions (user_id, endpoint);
+
+-- RLS 有効化
+ALTER TABLE push_subscriptions ENABLE ROW LEVEL SECURITY;
+
+-- ユーザーは自分のサブスクリプションのみ参照・操作可能
+CREATE POLICY "Users can view own push subscriptions"
+  ON push_subscriptions FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own push subscriptions"
+  ON push_subscriptions FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own push subscriptions"
+  ON push_subscriptions FOR UPDATE
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own push subscriptions"
+  ON push_subscriptions FOR DELETE
+  USING (auth.uid() = user_id);
+
+-- updated_at 自動更新トリガー
+CREATE OR REPLACE FUNCTION update_push_subscriptions_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER push_subscriptions_updated_at
+  BEFORE UPDATE ON push_subscriptions
+  FOR EACH ROW EXECUTE FUNCTION update_push_subscriptions_updated_at();
+
+
+-- User Preferences テーブル
+CREATE TABLE IF NOT EXISTS user_preferences (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE UNIQUE,
+  pwa_install_dismissed BOOLEAN NOT NULL DEFAULT false,
+  timezone TEXT NOT NULL DEFAULT 'Asia/Tokyo',
+  notification_preferences JSONB NOT NULL DEFAULT '{
+    "daily_reminder": false,
+    "reminder_time": "20:00",
+    "weekly_summary": false,
+    "achievement_alerts": true
+  }'::JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- RLS 有効化
+ALTER TABLE user_preferences ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own preferences"
+  ON user_preferences FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own preferences"
+  ON user_preferences FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own preferences"
+  ON user_preferences FOR UPDATE
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own preferences"
+  ON user_preferences FOR DELETE
+  USING (auth.uid() = user_id);
+
+-- updated_at 自動更新トリガー
+CREATE OR REPLACE FUNCTION update_user_preferences_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER user_preferences_updated_at
+  BEFORE UPDATE ON user_preferences
+  FOR EACH ROW EXECUTE FUNCTION update_user_preferences_updated_at();

--- a/database/push-subscriptions-and-preferences.sql
+++ b/database/push-subscriptions-and-preferences.sql
@@ -20,18 +20,22 @@ CREATE UNIQUE INDEX IF NOT EXISTS push_subscriptions_user_endpoint_idx
 ALTER TABLE push_subscriptions ENABLE ROW LEVEL SECURITY;
 
 -- ユーザーは自分のサブスクリプションのみ参照・操作可能
+DROP POLICY IF EXISTS "Users can view own push subscriptions" ON push_subscriptions;
 CREATE POLICY "Users can view own push subscriptions"
   ON push_subscriptions FOR SELECT
   USING (auth.uid() = user_id);
 
+DROP POLICY IF EXISTS "Users can insert own push subscriptions" ON push_subscriptions;
 CREATE POLICY "Users can insert own push subscriptions"
   ON push_subscriptions FOR INSERT
   WITH CHECK (auth.uid() = user_id);
 
+DROP POLICY IF EXISTS "Users can update own push subscriptions" ON push_subscriptions;
 CREATE POLICY "Users can update own push subscriptions"
   ON push_subscriptions FOR UPDATE
   USING (auth.uid() = user_id);
 
+DROP POLICY IF EXISTS "Users can delete own push subscriptions" ON push_subscriptions;
 CREATE POLICY "Users can delete own push subscriptions"
   ON push_subscriptions FOR DELETE
   USING (auth.uid() = user_id);
@@ -70,18 +74,22 @@ CREATE TABLE IF NOT EXISTS user_preferences (
 -- RLS 有効化
 ALTER TABLE user_preferences ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS "Users can view own preferences" ON user_preferences;
 CREATE POLICY "Users can view own preferences"
   ON user_preferences FOR SELECT
   USING (auth.uid() = user_id);
 
+DROP POLICY IF EXISTS "Users can insert own preferences" ON user_preferences;
 CREATE POLICY "Users can insert own preferences"
   ON user_preferences FOR INSERT
   WITH CHECK (auth.uid() = user_id);
 
+DROP POLICY IF EXISTS "Users can update own preferences" ON user_preferences;
 CREATE POLICY "Users can update own preferences"
   ON user_preferences FOR UPDATE
   USING (auth.uid() = user_id);
 
+DROP POLICY IF EXISTS "Users can delete own preferences" ON user_preferences;
 CREATE POLICY "Users can delete own preferences"
   ON user_preferences FOR DELETE
   USING (auth.uid() = user_id);

--- a/src/app/api/preferences/route.test.ts
+++ b/src/app/api/preferences/route.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const { mockSupabase } = vi.hoisted(() => {
+  const mockSupabase = {
+    auth: { getUser: vi.fn() },
+    from: vi.fn(),
+  };
+  return { mockSupabase };
+});
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn().mockResolvedValue(mockSupabase),
+}));
+
+import { GET, PUT } from './route';
+
+const USER = { id: 'user-1' };
+
+const mockPreferences = {
+  id: 'pref-1',
+  user_id: USER.id,
+  pwa_install_dismissed: false,
+  timezone: 'Asia/Tokyo',
+  notification_preferences: {
+    daily_reminder: false,
+    reminder_time: '20:00',
+    weekly_summary: false,
+    achievement_alerts: true,
+  },
+  created_at: '2026-04-19T00:00:00Z',
+  updated_at: '2026-04-19T00:00:00Z',
+};
+
+const makePutRequest = (body: unknown) =>
+  new NextRequest('http://localhost/api/preferences', {
+    method: 'PUT',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+describe('GET /api/preferences', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: null }, error: new Error('') });
+
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it('returns existing preferences', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: USER }, error: null });
+
+    const mockChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: mockPreferences, error: null }),
+    };
+    mockSupabase.from.mockReturnValue(mockChain);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+
+    const json = await res.json();
+    expect(json.preferences.timezone).toBe('Asia/Tokyo');
+  });
+
+  it('creates default preferences when not found', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: USER }, error: null });
+
+    const mockSelectChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: null,
+        error: { code: 'PGRST116', message: 'Not found' },
+      }),
+    };
+    const mockInsertChain = {
+      insert: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: mockPreferences, error: null }),
+    };
+    mockSupabase.from
+      .mockReturnValueOnce(mockSelectChain)
+      .mockReturnValueOnce(mockInsertChain);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 500 on other DB errors', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: USER }, error: null });
+
+    const mockChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: null,
+        error: { code: 'OTHER', message: 'DB error' },
+      }),
+    };
+    mockSupabase.from.mockReturnValue(mockChain);
+
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('PUT /api/preferences', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: null }, error: new Error('') });
+
+    const res = await PUT(makePutRequest({ pwa_install_dismissed: true }));
+    expect(res.status).toBe(401);
+  });
+
+  it('updates preferences successfully', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: USER }, error: null });
+
+    // First call: check existing (SELECT)
+    const existingChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: mockPreferences, error: null }),
+    };
+    // Second call: update
+    const singleFn = vi.fn().mockResolvedValue({
+      data: { ...mockPreferences, pwa_install_dismissed: true },
+      error: null,
+    });
+    const updateChain = {
+      update: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({ single: singleFn }),
+        }),
+      }),
+    };
+    mockSupabase.from
+      .mockReturnValueOnce(existingChain)
+      .mockReturnValueOnce(updateChain);
+
+    const res = await PUT(makePutRequest({ pwa_install_dismissed: true }));
+    expect(res.status).toBe(200);
+
+    const json = await res.json();
+    expect(json.preferences.pwa_install_dismissed).toBe(true);
+  });
+
+  it('returns 400 for invalid timezone', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: USER }, error: null });
+
+    const existingChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: mockPreferences, error: null }),
+    };
+    mockSupabase.from.mockReturnValue(existingChain);
+
+    const res = await PUT(makePutRequest({ timezone: '' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('merges notification_preferences with existing values', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: USER }, error: null });
+
+    const existingChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: mockPreferences, error: null }),
+    };
+    const updatedPrefs = {
+      ...mockPreferences,
+      notification_preferences: {
+        ...mockPreferences.notification_preferences,
+        daily_reminder: true,
+      },
+    };
+    const singleFn = vi.fn().mockResolvedValue({ data: updatedPrefs, error: null });
+    const updateChain = {
+      update: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({ single: singleFn }),
+        }),
+      }),
+    };
+    mockSupabase.from
+      .mockReturnValueOnce(existingChain)
+      .mockReturnValueOnce(updateChain);
+
+    const res = await PUT(makePutRequest({ notification_preferences: { daily_reminder: true } }));
+    expect(res.status).toBe(200);
+
+    const json = await res.json();
+    expect(json.preferences.notification_preferences.daily_reminder).toBe(true);
+    expect(json.preferences.notification_preferences.achievement_alerts).toBe(true);
+  });
+});

--- a/src/app/api/preferences/route.ts
+++ b/src/app/api/preferences/route.ts
@@ -1,0 +1,155 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import type { NotificationPreferences } from '@/types/push';
+
+const DEFAULT_PREFERENCES = {
+  pwa_install_dismissed: false,
+  timezone: 'Asia/Tokyo',
+  notification_preferences: {
+    daily_reminder: false,
+    reminder_time: '20:00',
+    weekly_summary: false,
+    achievement_alerts: true,
+  } as NotificationPreferences,
+};
+
+export async function GET() {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser();
+
+    if (userError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { data, error } = await supabase
+      .from('user_preferences')
+      .select('*')
+      .eq('user_id', user.id)
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116') {
+        // 存在しない場合はデフォルト値で作成
+        const { data: created, error: createError } = await supabase
+          .from('user_preferences')
+          .insert({ user_id: user.id, ...DEFAULT_PREFERENCES })
+          .select()
+          .single();
+
+        if (createError) {
+          return NextResponse.json(
+            { error: 'Failed to create preferences' },
+            { status: 500 },
+          );
+        }
+
+        return NextResponse.json({ preferences: created });
+      }
+
+      return NextResponse.json(
+        { error: 'Failed to fetch preferences' },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({ preferences: data });
+  } catch {
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser();
+
+    if (userError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { pwa_install_dismissed, timezone, notification_preferences } = body;
+
+    // 既存設定を取得
+    const { data: existing } = await supabase
+      .from('user_preferences')
+      .select('*')
+      .eq('user_id', user.id)
+      .single();
+
+    const updates: Record<string, unknown> = {
+      updated_at: new Date().toISOString(),
+    };
+
+    if (pwa_install_dismissed !== undefined) {
+      updates.pwa_install_dismissed = Boolean(pwa_install_dismissed);
+    }
+    if (timezone !== undefined) {
+      if (typeof timezone !== 'string' || timezone.trim() === '') {
+        return NextResponse.json(
+          { error: 'timezone は有効な文字列である必要があります。' },
+          { status: 400 },
+        );
+      }
+      updates.timezone = timezone.trim();
+    }
+    if (notification_preferences !== undefined) {
+      const current =
+        existing?.notification_preferences ?? DEFAULT_PREFERENCES.notification_preferences;
+      updates.notification_preferences = { ...current, ...notification_preferences };
+    }
+
+    if (existing) {
+      const { data, error } = await supabase
+        .from('user_preferences')
+        .update(updates)
+        .eq('user_id', user.id)
+        .select()
+        .single();
+
+      if (error) {
+        return NextResponse.json(
+          { error: 'Failed to update preferences' },
+          { status: 500 },
+        );
+      }
+
+      return NextResponse.json({ preferences: data });
+    }
+
+    // 存在しない場合は作成
+    const { data, error } = await supabase
+      .from('user_preferences')
+      .insert({
+        user_id: user.id,
+        ...DEFAULT_PREFERENCES,
+        ...updates,
+      })
+      .select()
+      .single();
+
+    if (error) {
+      return NextResponse.json(
+        { error: 'Failed to create preferences' },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({ preferences: data });
+  } catch {
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/preferences/route.ts
+++ b/src/app/api/preferences/route.ts
@@ -77,23 +77,46 @@ export async function PUT(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const body = await request.json();
-    const { pwa_install_dismissed, timezone, notification_preferences } = body;
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
 
-    // 既存設定を取得
-    const { data: existing } = await supabase
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+    }
+
+    const { pwa_install_dismissed, timezone, notification_preferences } =
+      body as Record<string, unknown>;
+
+    // 既存設定を取得（エラーを明示的に処理する）
+    const { data: existing, error: existingError } = await supabase
       .from('user_preferences')
       .select('*')
       .eq('user_id', user.id)
       .single();
 
-    const updates: Record<string, unknown> = {
-      updated_at: new Date().toISOString(),
-    };
+    if (existingError && existingError.code !== 'PGRST116') {
+      return NextResponse.json(
+        { error: 'Failed to fetch preferences' },
+        { status: 500 },
+      );
+    }
+
+    const updates: Record<string, unknown> = {};
 
     if (pwa_install_dismissed !== undefined) {
-      updates.pwa_install_dismissed = Boolean(pwa_install_dismissed);
+      if (typeof pwa_install_dismissed !== 'boolean') {
+        return NextResponse.json(
+          { error: 'pwa_install_dismissed は boolean である必要があります。' },
+          { status: 400 },
+        );
+      }
+      updates.pwa_install_dismissed = pwa_install_dismissed;
     }
+
     if (timezone !== undefined) {
       if (typeof timezone !== 'string' || timezone.trim() === '') {
         return NextResponse.json(
@@ -103,7 +126,18 @@ export async function PUT(request: NextRequest) {
       }
       updates.timezone = timezone.trim();
     }
+
     if (notification_preferences !== undefined) {
+      if (
+        typeof notification_preferences !== 'object' ||
+        notification_preferences === null ||
+        Array.isArray(notification_preferences)
+      ) {
+        return NextResponse.json(
+          { error: 'notification_preferences はオブジェクトである必要があります。' },
+          { status: 400 },
+        );
+      }
       const current =
         existing?.notification_preferences ?? DEFAULT_PREFERENCES.notification_preferences;
       updates.notification_preferences = { ...current, ...notification_preferences };

--- a/src/app/api/preferences/route.ts
+++ b/src/app/api/preferences/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import type { NotificationPreferences } from '@/types/push';
+import { validateNotificationPreferences } from '@/lib/push/validation';
 
 const DEFAULT_PREFERENCES = {
   pwa_install_dismissed: false,
@@ -12,6 +13,15 @@ const DEFAULT_PREFERENCES = {
     achievement_alerts: true,
   } as NotificationPreferences,
 };
+
+async function refetchPreferences(supabase: Awaited<ReturnType<typeof createClient>>, userId: string) {
+  const { data, error } = await supabase
+    .from('user_preferences')
+    .select('*')
+    .eq('user_id', userId)
+    .single();
+  return { data, error };
+}
 
 export async function GET() {
   try {
@@ -41,6 +51,14 @@ export async function GET() {
           .single();
 
         if (createError) {
+          // 同時リクエストで先に作成済みの場合は再フェッチ
+          if (createError.code === '23505') {
+            const { data: refetched, error: refetchError } = await refetchPreferences(supabase, user.id);
+            if (refetchError) {
+              return NextResponse.json({ error: 'Failed to fetch preferences' }, { status: 500 });
+            }
+            return NextResponse.json({ preferences: refetched });
+          }
           return NextResponse.json(
             { error: 'Failed to create preferences' },
             { status: 500 },
@@ -138,6 +156,12 @@ export async function PUT(request: NextRequest) {
           { status: 400 },
         );
       }
+      const validationError = validateNotificationPreferences(
+        notification_preferences as Record<string, unknown>,
+      );
+      if (validationError) {
+        return NextResponse.json({ error: validationError }, { status: 400 });
+      }
       const current =
         existing?.notification_preferences ?? DEFAULT_PREFERENCES.notification_preferences;
       updates.notification_preferences = { ...current, ...notification_preferences };
@@ -173,6 +197,20 @@ export async function PUT(request: NextRequest) {
       .single();
 
     if (error) {
+      // 同時リクエストで先に作成済みの場合は更新に切り替え
+      if (error.code === '23505') {
+        const { data: updated, error: updateError } = await supabase
+          .from('user_preferences')
+          .update(updates)
+          .eq('user_id', user.id)
+          .select()
+          .single();
+
+        if (updateError) {
+          return NextResponse.json({ error: 'Failed to update preferences' }, { status: 500 });
+        }
+        return NextResponse.json({ preferences: updated });
+      }
       return NextResponse.json(
         { error: 'Failed to create preferences' },
         { status: 500 },

--- a/src/app/api/push/subscribe/route.test.ts
+++ b/src/app/api/push/subscribe/route.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const { mockSupabase } = vi.hoisted(() => {
+  const mockSupabase = {
+    auth: { getUser: vi.fn() },
+    from: vi.fn(),
+  };
+  return { mockSupabase };
+});
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn().mockResolvedValue(mockSupabase),
+}));
+
+vi.mock('@/lib/push/encryption', () => ({
+  validatePushSubscriptionFields: vi.fn().mockReturnValue(null),
+}));
+
+import { POST } from './route';
+import { validatePushSubscriptionFields } from '@/lib/push/encryption';
+
+const USER = { id: 'user-1' };
+const VALID_BODY = {
+  endpoint: 'https://fcm.googleapis.com/push/abc',
+  p256dh: 'BNb2B0dAi8Q=',
+  auth: 'tBHItJI5svbpez7KI4CCXg==',
+};
+
+const makeRequest = (body: unknown) =>
+  new NextRequest('http://localhost/api/push/subscribe', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+describe('POST /api/push/subscribe', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(validatePushSubscriptionFields).mockReturnValue(null);
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: null }, error: new Error('') });
+
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when required fields are missing', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: USER }, error: null });
+
+    const res = await POST(makeRequest({ endpoint: 'https://example.com' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when validation fails', async () => {
+    vi.mocked(validatePushSubscriptionFields).mockReturnValue('endpoint は有効な HTTPS URL である必要があります。');
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: USER }, error: null });
+
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 201 when subscription is created', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: USER }, error: null });
+
+    const mockChain = {
+      upsert: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: { id: 'sub-1', ...VALID_BODY, user_id: USER.id, is_active: true },
+        error: null,
+      }),
+    };
+    mockSupabase.from.mockReturnValue(mockChain);
+
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(201);
+
+    const json = await res.json();
+    expect(json.subscription.id).toBe('sub-1');
+  });
+
+  it('returns 500 when database fails', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: USER }, error: null });
+
+    const mockChain = {
+      upsert: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null, error: { message: 'DB error' } }),
+    };
+    mockSupabase.from.mockReturnValue(mockChain);
+
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/push/subscribe/route.ts
+++ b/src/app/api/push/subscribe/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { validatePushSubscriptionFields } from '@/lib/push/encryption';
+
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser();
+
+    if (userError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { endpoint, p256dh, auth, user_agent, browser } = body;
+
+    if (!endpoint || !p256dh || !auth) {
+      return NextResponse.json(
+        { error: 'endpoint, p256dh, auth は必須です。' },
+        { status: 400 },
+      );
+    }
+
+    const validationError = validatePushSubscriptionFields(endpoint, p256dh, auth);
+    if (validationError) {
+      return NextResponse.json({ error: validationError }, { status: 400 });
+    }
+
+    const { data, error } = await supabase
+      .from('push_subscriptions')
+      .upsert(
+        {
+          user_id: user.id,
+          endpoint,
+          p256dh,
+          auth,
+          user_agent: user_agent ?? null,
+          browser: browser ?? null,
+          is_active: true,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'user_id,endpoint' },
+      )
+      .select()
+      .single();
+
+    if (error) {
+      return NextResponse.json(
+        { error: 'Failed to save push subscription' },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({ subscription: data }, { status: 201 });
+  } catch {
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/push/subscribe/route.ts
+++ b/src/app/api/push/subscribe/route.ts
@@ -14,10 +14,30 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const body = await request.json();
-    const { endpoint, p256dh, auth, user_agent, browser } = body;
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
 
-    if (!endpoint || !p256dh || !auth) {
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return NextResponse.json(
+        { error: 'endpoint, p256dh, auth は必須です。' },
+        { status: 400 },
+      );
+    }
+
+    const { endpoint, p256dh, auth, user_agent, browser } = body as Record<string, unknown>;
+
+    if (
+      typeof endpoint !== 'string' ||
+      typeof p256dh !== 'string' ||
+      typeof auth !== 'string' ||
+      endpoint.trim() === '' ||
+      p256dh.trim() === '' ||
+      auth.trim() === ''
+    ) {
       return NextResponse.json(
         { error: 'endpoint, p256dh, auth は必須です。' },
         { status: 400 },
@@ -37,10 +57,9 @@ export async function POST(request: NextRequest) {
           endpoint,
           p256dh,
           auth,
-          user_agent: user_agent ?? null,
-          browser: browser ?? null,
+          user_agent: typeof user_agent === 'string' ? user_agent : null,
+          browser: typeof browser === 'string' ? browser : null,
           is_active: true,
-          updated_at: new Date().toISOString(),
         },
         { onConflict: 'user_id,endpoint' },
       )

--- a/src/app/api/push/unsubscribe/route.test.ts
+++ b/src/app/api/push/unsubscribe/route.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const { mockSupabase } = vi.hoisted(() => {
+  const mockSupabase = {
+    auth: { getUser: vi.fn() },
+    from: vi.fn(),
+  };
+  return { mockSupabase };
+});
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn().mockResolvedValue(mockSupabase),
+}));
+
+import { POST } from './route';
+
+const USER = { id: 'user-1' };
+const ENDPOINT = 'https://fcm.googleapis.com/push/abc';
+
+const makeRequest = (body: unknown) =>
+  new NextRequest('http://localhost/api/push/unsubscribe', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+describe('POST /api/push/unsubscribe', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: null }, error: new Error('') });
+
+    const res = await POST(makeRequest({ endpoint: ENDPOINT }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when endpoint is missing', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: USER }, error: null });
+
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 200 on success', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: USER }, error: null });
+
+    const eqInner = vi.fn().mockResolvedValue({ error: null });
+    const eqOuter = vi.fn().mockReturnValue({ eq: eqInner });
+    const update = vi.fn().mockReturnValue({ eq: eqOuter });
+    mockSupabase.from.mockReturnValue({ update });
+
+    const res = await POST(makeRequest({ endpoint: ENDPOINT }));
+    expect(res.status).toBe(200);
+
+    const json = await res.json();
+    expect(json.success).toBe(true);
+  });
+
+  it('returns 500 when database fails', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: USER }, error: null });
+
+    const eqInner = vi.fn().mockResolvedValue({ error: { message: 'DB error' } });
+    const eqOuter = vi.fn().mockReturnValue({ eq: eqInner });
+    const update = vi.fn().mockReturnValue({ eq: eqOuter });
+    mockSupabase.from.mockReturnValue({ update });
+
+    const res = await POST(makeRequest({ endpoint: ENDPOINT }));
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/push/unsubscribe/route.ts
+++ b/src/app/api/push/unsubscribe/route.ts
@@ -13,10 +13,20 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const body = await request.json();
-    const { endpoint } = body;
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
 
-    if (!endpoint || typeof endpoint !== 'string') {
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return NextResponse.json({ error: 'endpoint は必須です。' }, { status: 400 });
+    }
+
+    const { endpoint } = body as { endpoint?: unknown };
+
+    if (typeof endpoint !== 'string' || endpoint.trim() === '') {
       return NextResponse.json(
         { error: 'endpoint は必須です。' },
         { status: 400 },
@@ -25,7 +35,7 @@ export async function POST(request: NextRequest) {
 
     const { error } = await supabase
       .from('push_subscriptions')
-      .update({ is_active: false, updated_at: new Date().toISOString() })
+      .update({ is_active: false })
       .eq('user_id', user.id)
       .eq('endpoint', endpoint);
 

--- a/src/app/api/push/unsubscribe/route.ts
+++ b/src/app/api/push/unsubscribe/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser();
+
+    if (userError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { endpoint } = body;
+
+    if (!endpoint || typeof endpoint !== 'string') {
+      return NextResponse.json(
+        { error: 'endpoint は必須です。' },
+        { status: 400 },
+      );
+    }
+
+    const { error } = await supabase
+      .from('push_subscriptions')
+      .update({ is_active: false, updated_at: new Date().toISOString() })
+      .eq('user_id', user.id)
+      .eq('endpoint', endpoint);
+
+    if (error) {
+      return NextResponse.json(
+        { error: 'Failed to unsubscribe push subscription' },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({ success: true });
+  } catch {
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/push/encryption.test.ts
+++ b/src/lib/push/encryption.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import {
+  hashEndpoint,
+  generateNonce,
+  validateEndpoint,
+  validateBase64url,
+  validatePushSubscriptionFields,
+} from './encryption';
+
+describe('encryption', () => {
+  describe('hashEndpoint', () => {
+    it('returns a 64-char hex string', () => {
+      const hash = hashEndpoint('https://example.com/push');
+      expect(hash).toHaveLength(64);
+      expect(hash).toMatch(/^[0-9a-f]+$/);
+    });
+
+    it('produces the same hash for the same input', () => {
+      const url = 'https://fcm.googleapis.com/fcm/send/abc123';
+      expect(hashEndpoint(url)).toBe(hashEndpoint(url));
+    });
+
+    it('produces different hashes for different inputs', () => {
+      expect(hashEndpoint('https://a.com')).not.toBe(hashEndpoint('https://b.com'));
+    });
+  });
+
+  describe('generateNonce', () => {
+    it('returns a non-empty base64url string', () => {
+      const nonce = generateNonce();
+      expect(nonce.length).toBeGreaterThan(0);
+    });
+
+    it('returns different values on each call', () => {
+      expect(generateNonce()).not.toBe(generateNonce());
+    });
+  });
+
+  describe('validateEndpoint', () => {
+    it('accepts valid HTTPS URLs', () => {
+      expect(validateEndpoint('https://fcm.googleapis.com/fcm/send/abc')).toBe(true);
+      expect(validateEndpoint('https://push.example.com/endpoint')).toBe(true);
+    });
+
+    it('rejects HTTP URLs', () => {
+      expect(validateEndpoint('http://example.com/push')).toBe(false);
+    });
+
+    it('rejects non-URL strings', () => {
+      expect(validateEndpoint('not-a-url')).toBe(false);
+      expect(validateEndpoint('')).toBe(false);
+    });
+  });
+
+  describe('validateBase64url', () => {
+    it('accepts valid base64url strings', () => {
+      expect(validateBase64url('abc123-_==')).toBe(true);
+      expect(validateBase64url('BNb2B0dAi8Q=')).toBe(true);
+    });
+
+    it('rejects empty strings', () => {
+      expect(validateBase64url('')).toBe(false);
+    });
+
+    it('rejects strings with invalid characters', () => {
+      expect(validateBase64url('abc!@#')).toBe(false);
+    });
+  });
+
+  describe('validatePushSubscriptionFields', () => {
+    const validEndpoint = 'https://fcm.googleapis.com/push/abc';
+    const validP256dh = 'BNb2B0dAi8Q=';
+    const validAuth = 'tBHItJI5svbpez7KI4CCXg==';
+
+    it('returns null for valid fields', () => {
+      expect(validatePushSubscriptionFields(validEndpoint, validP256dh, validAuth)).toBeNull();
+    });
+
+    it('returns error for invalid endpoint', () => {
+      const result = validatePushSubscriptionFields('http://insecure.com', validP256dh, validAuth);
+      expect(result).toContain('endpoint');
+    });
+
+    it('returns error for invalid p256dh', () => {
+      const result = validatePushSubscriptionFields(validEndpoint, '', validAuth);
+      expect(result).toContain('p256dh');
+    });
+
+    it('returns error for invalid auth', () => {
+      const result = validatePushSubscriptionFields(validEndpoint, validP256dh, '');
+      expect(result).toContain('auth');
+    });
+  });
+});

--- a/src/lib/push/encryption.ts
+++ b/src/lib/push/encryption.ts
@@ -1,0 +1,57 @@
+import { createHash, randomBytes } from 'crypto';
+
+/**
+ * Push subscription endpoint を SHA-256 ハッシュ化して保存用の安全な識別子を生成する。
+ * 実際の endpoint URL はそのままDBに保存するが、ログ出力時はこのハッシュを使う。
+ */
+export function hashEndpoint(endpoint: string): string {
+  return createHash('sha256').update(endpoint).digest('hex');
+}
+
+/**
+ * Web Push 用の VAPID キーペアを生成するためのランダムシードを返す。
+ * 実際の VAPID キー生成は web-push ライブラリで行う想定。
+ */
+export function generateNonce(): string {
+  return randomBytes(16).toString('base64url');
+}
+
+/**
+ * Push subscription の endpoint が有効な HTTPS URL かを検証する。
+ */
+export function validateEndpoint(endpoint: string): boolean {
+  try {
+    const url = new URL(endpoint);
+    return url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * p256dh / auth キーが Base64url 形式かを検証する。
+ */
+export function validateBase64url(value: string): boolean {
+  return /^[A-Za-z0-9\-_]+=*$/.test(value) && value.length > 0;
+}
+
+/**
+ * Push subscription の各フィールドを検証し、エラーメッセージを返す。
+ * 問題がなければ null を返す。
+ */
+export function validatePushSubscriptionFields(
+  endpoint: string,
+  p256dh: string,
+  auth: string,
+): string | null {
+  if (!validateEndpoint(endpoint)) {
+    return 'endpoint は有効な HTTPS URL である必要があります。';
+  }
+  if (!validateBase64url(p256dh)) {
+    return 'p256dh は有効な Base64url 文字列である必要があります。';
+  }
+  if (!validateBase64url(auth)) {
+    return 'auth は有効な Base64url 文字列である必要があります。';
+  }
+  return null;
+}

--- a/src/lib/push/validation.test.ts
+++ b/src/lib/push/validation.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { validateNotificationPreferences } from './validation';
+
+describe('validateNotificationPreferences', () => {
+  describe('unknown keys', () => {
+    it('rejects unknown keys', () => {
+      expect(validateNotificationPreferences({ unknown: true })).toMatch(/不明なキー/);
+    });
+  });
+
+  describe('boolean fields', () => {
+    it.each(['daily_reminder', 'weekly_summary', 'achievement_alerts'] as const)(
+      'rejects non-boolean %s',
+      (key) => {
+        expect(validateNotificationPreferences({ [key]: 'true' })).toMatch(new RegExp(key));
+      },
+    );
+
+    it('accepts valid boolean values', () => {
+      expect(
+        validateNotificationPreferences({
+          daily_reminder: true,
+          weekly_summary: false,
+          achievement_alerts: true,
+        }),
+      ).toBeNull();
+    });
+  });
+
+  describe('reminder_time', () => {
+    it.each(['00:00', '09:30', '12:00', '23:59', '20:00'])('accepts valid time %s', (t) => {
+      expect(validateNotificationPreferences({ reminder_time: t })).toBeNull();
+    });
+
+    it.each(['24:00', '25:30', '99:99', '12:60', '12:99', '1:00', '12:0', 'ab:cd', ''])(
+      'rejects invalid time %s',
+      (t) => {
+        expect(validateNotificationPreferences({ reminder_time: t })).toMatch(/reminder_time/);
+      },
+    );
+
+    it('rejects non-string reminder_time', () => {
+      expect(validateNotificationPreferences({ reminder_time: 2000 })).toMatch(/reminder_time/);
+    });
+  });
+
+  it('returns null for an empty payload', () => {
+    expect(validateNotificationPreferences({})).toBeNull();
+  });
+});

--- a/src/lib/push/validation.ts
+++ b/src/lib/push/validation.ts
@@ -1,0 +1,36 @@
+const VALID_NOTIFICATION_KEYS = new Set([
+  'daily_reminder',
+  'reminder_time',
+  'weekly_summary',
+  'achievement_alerts',
+]);
+
+/**
+ * notification_preferences ペイロードのキーと型を検証する。
+ * 問題がなければ null、エラーがあれば日本語メッセージを返す。
+ */
+export function validateNotificationPreferences(
+  payload: Record<string, unknown>,
+): string | null {
+  for (const key of Object.keys(payload)) {
+    if (!VALID_NOTIFICATION_KEYS.has(key)) {
+      return `不明なキー "${key}" が含まれています。`;
+    }
+  }
+  if ('daily_reminder' in payload && typeof payload.daily_reminder !== 'boolean') {
+    return 'daily_reminder は boolean である必要があります。';
+  }
+  if ('weekly_summary' in payload && typeof payload.weekly_summary !== 'boolean') {
+    return 'weekly_summary は boolean である必要があります。';
+  }
+  if ('achievement_alerts' in payload && typeof payload.achievement_alerts !== 'boolean') {
+    return 'achievement_alerts は boolean である必要があります。';
+  }
+  if ('reminder_time' in payload) {
+    const t = payload.reminder_time;
+    if (typeof t !== 'string' || !/^\d{2}:\d{2}$/.test(t)) {
+      return 'reminder_time は HH:MM 形式である必要があります。';
+    }
+  }
+  return null;
+}

--- a/src/lib/push/validation.ts
+++ b/src/lib/push/validation.ts
@@ -28,8 +28,8 @@ export function validateNotificationPreferences(
   }
   if ('reminder_time' in payload) {
     const t = payload.reminder_time;
-    if (typeof t !== 'string' || !/^\d{2}:\d{2}$/.test(t)) {
-      return 'reminder_time は HH:MM 形式である必要があります。';
+    if (typeof t !== 'string' || !/^(?:[01]\d|2[0-3]):[0-5]\d$/.test(t)) {
+      return 'reminder_time は HH:MM 形式 (00:00〜23:59) である必要があります。';
     }
   }
   return null;

--- a/src/services/preferencesService.test.ts
+++ b/src/services/preferencesService.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/supabase/client', () => ({
+  supabase: {
+    auth: { getUser: vi.fn() },
+    from: vi.fn(),
+  },
+}));
+
+import { preferencesService } from './preferencesService';
+import { supabase } from '@/lib/supabase/client';
+
+const USER_ID = 'user-1';
+
+const mockPreferences = {
+  id: 'pref-1',
+  user_id: USER_ID,
+  pwa_install_dismissed: false,
+  timezone: 'Asia/Tokyo',
+  notification_preferences: {
+    daily_reminder: false,
+    reminder_time: '20:00',
+    weekly_summary: false,
+    achievement_alerts: true,
+  },
+  created_at: '2026-04-19T00:00:00Z',
+  updated_at: '2026-04-19T00:00:00Z',
+};
+
+describe('preferencesService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getPreferences', () => {
+    it('returns existing preferences', async () => {
+      vi.mocked(supabase.auth.getUser).mockResolvedValue({
+        data: { user: { id: USER_ID } },
+        error: null,
+      } as any);
+
+      const mockChain = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: mockPreferences, error: null }),
+      };
+      vi.mocked(supabase.from).mockReturnValue(mockChain as any);
+
+      const result = await preferencesService.getPreferences(USER_ID);
+      expect(result).toEqual(mockPreferences);
+    });
+
+    it('creates default preferences when not found (PGRST116)', async () => {
+      vi.mocked(supabase.auth.getUser).mockResolvedValue({
+        data: { user: { id: USER_ID } },
+        error: null,
+      } as any);
+
+      const mockSelectChain = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({
+          data: null,
+          error: { code: 'PGRST116', message: 'Not found' },
+        }),
+      };
+      const mockInsertChain = {
+        insert: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: mockPreferences, error: null }),
+      };
+
+      vi.mocked(supabase.from)
+        .mockReturnValueOnce(mockSelectChain as any)
+        .mockReturnValueOnce(mockInsertChain as any);
+
+      const result = await preferencesService.getPreferences(USER_ID);
+      expect(result).toEqual(mockPreferences);
+    });
+
+    it('throws AUTH_ERROR when not authenticated', async () => {
+      vi.mocked(supabase.auth.getUser).mockResolvedValue({
+        data: { user: null },
+        error: new Error('Not authenticated'),
+      } as any);
+
+      await expect(preferencesService.getPreferences(USER_ID)).rejects.toMatchObject({
+        code: 'AUTH_ERROR',
+      });
+    });
+
+    it('throws DB_ERROR on other DB errors', async () => {
+      vi.mocked(supabase.auth.getUser).mockResolvedValue({
+        data: { user: { id: USER_ID } },
+        error: null,
+      } as any);
+
+      const mockChain = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({
+          data: null,
+          error: { code: 'OTHER', message: 'DB error' },
+        }),
+      };
+      vi.mocked(supabase.from).mockReturnValue(mockChain as any);
+
+      await expect(preferencesService.getPreferences(USER_ID)).rejects.toMatchObject({
+        code: 'DB_ERROR',
+      });
+    });
+  });
+
+  describe('updatePreferences', () => {
+    it('merges notification_preferences with existing values', async () => {
+      vi.mocked(supabase.auth.getUser).mockResolvedValue({
+        data: { user: { id: USER_ID } },
+        error: null,
+      } as any);
+
+      // getPreferences の SELECT (auth guard + select)
+      const selectChain = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: mockPreferences, error: null }),
+      };
+      const updatedPreferences = {
+        ...mockPreferences,
+        notification_preferences: {
+          ...mockPreferences.notification_preferences,
+          daily_reminder: true,
+        },
+      };
+      const singleFn = vi.fn().mockResolvedValue({ data: updatedPreferences, error: null });
+      const updateChain = {
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnValue({ single: singleFn }),
+          }),
+        }),
+      };
+
+      vi.mocked(supabase.from)
+        .mockReturnValueOnce(selectChain as any) // getPreferences
+        .mockReturnValueOnce(updateChain as any); // update call
+
+      const result = await preferencesService.updatePreferences(USER_ID, {
+        notification_preferences: { daily_reminder: true },
+      });
+
+      expect(result.notification_preferences.daily_reminder).toBe(true);
+      expect(result.notification_preferences.achievement_alerts).toBe(true);
+    });
+
+    it('throws AUTH_ERROR when not authenticated', async () => {
+      vi.mocked(supabase.auth.getUser).mockResolvedValue({
+        data: { user: null },
+        error: new Error('Not authenticated'),
+      } as any);
+
+      await expect(
+        preferencesService.updatePreferences(USER_ID, { pwa_install_dismissed: true }),
+      ).rejects.toMatchObject({ code: 'AUTH_ERROR' });
+    });
+  });
+});

--- a/src/services/preferencesService.test.ts
+++ b/src/services/preferencesService.test.ts
@@ -162,5 +162,35 @@ describe('preferencesService', () => {
         preferencesService.updatePreferences(USER_ID, { pwa_install_dismissed: true }),
       ).rejects.toMatchObject({ code: 'AUTH_ERROR' });
     });
+
+    it('throws DB_ERROR when update fails', async () => {
+      vi.mocked(supabase.auth.getUser).mockResolvedValue({
+        data: { user: { id: USER_ID } },
+        error: null,
+      } as any);
+
+      const selectChain = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: mockPreferences, error: null }),
+      };
+      const updateChain = {
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({ data: null, error: { message: 'Update failed' } }),
+            }),
+          }),
+        }),
+      };
+
+      vi.mocked(supabase.from)
+        .mockReturnValueOnce(selectChain as any)
+        .mockReturnValueOnce(updateChain as any);
+
+      await expect(
+        preferencesService.updatePreferences(USER_ID, { pwa_install_dismissed: true }),
+      ).rejects.toMatchObject({ code: 'DB_ERROR' });
+    });
   });
 });

--- a/src/services/preferencesService.ts
+++ b/src/services/preferencesService.ts
@@ -1,0 +1,101 @@
+import { supabase } from '@/lib/supabase/client';
+import type {
+  UserPreferences,
+  UpdateUserPreferencesRequest,
+  NotificationPreferences,
+} from '@/types/push';
+
+const DEFAULT_NOTIFICATION_PREFERENCES: NotificationPreferences = {
+  daily_reminder: false,
+  reminder_time: '20:00',
+  weekly_summary: false,
+  achievement_alerts: true,
+};
+
+export const preferencesService = {
+  async getPreferences(userId: string): Promise<UserPreferences> {
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user || user.id !== userId) {
+      throw { code: 'AUTH_ERROR', message: '認証されていません。ログインしてください。' };
+    }
+
+    const { data, error } = await supabase
+      .from('user_preferences')
+      .select('*')
+      .eq('user_id', userId)
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116') {
+        // レコードが存在しない場合はデフォルト値で作成
+        return this.createDefaultPreferences(userId);
+      }
+      throw { code: 'DB_ERROR', message: error.message };
+    }
+
+    return data as UserPreferences;
+  },
+
+  async createDefaultPreferences(userId: string): Promise<UserPreferences> {
+    const { data, error } = await supabase
+      .from('user_preferences')
+      .insert({
+        user_id: userId,
+        pwa_install_dismissed: false,
+        timezone: 'Asia/Tokyo',
+        notification_preferences: DEFAULT_NOTIFICATION_PREFERENCES,
+      })
+      .select()
+      .single();
+
+    if (error) {
+      throw { code: 'DB_ERROR', message: error.message };
+    }
+
+    return data as UserPreferences;
+  },
+
+  async updatePreferences(
+    userId: string,
+    updates: UpdateUserPreferencesRequest,
+  ): Promise<UserPreferences> {
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user || user.id !== userId) {
+      throw { code: 'AUTH_ERROR', message: '認証されていません。ログインしてください。' };
+    }
+
+    const current = await this.getPreferences(userId);
+
+    const merged: Partial<UserPreferences> = {
+      updated_at: new Date().toISOString(),
+    };
+
+    if (updates.pwa_install_dismissed !== undefined) {
+      merged.pwa_install_dismissed = updates.pwa_install_dismissed;
+    }
+    if (updates.timezone !== undefined) {
+      merged.timezone = updates.timezone;
+    }
+    if (updates.notification_preferences !== undefined) {
+      merged.notification_preferences = {
+        ...current.notification_preferences,
+        ...updates.notification_preferences,
+      };
+    }
+
+    const { data, error } = await supabase
+      .from('user_preferences')
+      .update(merged)
+      .eq('user_id', userId)
+      .select()
+      .single();
+
+    if (error) {
+      throw { code: 'DB_ERROR', message: error.message };
+    }
+
+    return data as UserPreferences;
+  },
+};

--- a/src/services/preferencesService.ts
+++ b/src/services/preferencesService.ts
@@ -33,6 +33,19 @@ export const preferencesService = {
       .single();
 
     if (error) {
+      // UNIQUE 制約違反 = 別リクエストが先に作成済み → 再フェッチ
+      if (error.code === '23505') {
+        const { data: existing, error: fetchError } = await supabase
+          .from('user_preferences')
+          .select('*')
+          .eq('user_id', userId)
+          .single();
+
+        if (fetchError) {
+          throw { code: 'DB_ERROR', message: fetchError.message };
+        }
+        return existing as UserPreferences;
+      }
       throw { code: 'DB_ERROR', message: error.message };
     }
 

--- a/src/services/preferencesService.ts
+++ b/src/services/preferencesService.ts
@@ -13,31 +13,14 @@ const DEFAULT_NOTIFICATION_PREFERENCES: NotificationPreferences = {
 };
 
 export const preferencesService = {
-  async getPreferences(userId: string): Promise<UserPreferences> {
+  async _verifyAuth(userId: string): Promise<void> {
     const { data: { user }, error: authError } = await supabase.auth.getUser();
-
     if (authError || !user || user.id !== userId) {
       throw { code: 'AUTH_ERROR', message: '認証されていません。ログインしてください。' };
     }
-
-    const { data, error } = await supabase
-      .from('user_preferences')
-      .select('*')
-      .eq('user_id', userId)
-      .single();
-
-    if (error) {
-      if (error.code === 'PGRST116') {
-        // レコードが存在しない場合はデフォルト値で作成
-        return this.createDefaultPreferences(userId);
-      }
-      throw { code: 'DB_ERROR', message: error.message };
-    }
-
-    return data as UserPreferences;
   },
 
-  async createDefaultPreferences(userId: string): Promise<UserPreferences> {
+  async _createDefaultPreferences(userId: string): Promise<UserPreferences> {
     const { data, error } = await supabase
       .from('user_preferences')
       .insert({
@@ -56,21 +39,37 @@ export const preferencesService = {
     return data as UserPreferences;
   },
 
+  async _fetchOrCreate(userId: string): Promise<UserPreferences> {
+    const { data, error } = await supabase
+      .from('user_preferences')
+      .select('*')
+      .eq('user_id', userId)
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116') {
+        return this._createDefaultPreferences(userId);
+      }
+      throw { code: 'DB_ERROR', message: error.message };
+    }
+
+    return data as UserPreferences;
+  },
+
+  async getPreferences(userId: string): Promise<UserPreferences> {
+    await this._verifyAuth(userId);
+    return this._fetchOrCreate(userId);
+  },
+
   async updatePreferences(
     userId: string,
     updates: UpdateUserPreferencesRequest,
   ): Promise<UserPreferences> {
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    await this._verifyAuth(userId);
 
-    if (authError || !user || user.id !== userId) {
-      throw { code: 'AUTH_ERROR', message: '認証されていません。ログインしてください。' };
-    }
+    const current = await this._fetchOrCreate(userId);
 
-    const current = await this.getPreferences(userId);
-
-    const merged: Partial<UserPreferences> = {
-      updated_at: new Date().toISOString(),
-    };
+    const merged: Partial<UserPreferences> = {};
 
     if (updates.pwa_install_dismissed !== undefined) {
       merged.pwa_install_dismissed = updates.pwa_install_dismissed;

--- a/src/services/pushService.test.ts
+++ b/src/services/pushService.test.ts
@@ -139,6 +139,22 @@ describe('pushService', () => {
         code: 'AUTH_ERROR',
       });
     });
+
+    it('throws DB_ERROR when database update fails', async () => {
+      vi.mocked(supabase.auth.getUser).mockResolvedValue({
+        data: { user: { id: USER_ID } },
+        error: null,
+      } as any);
+
+      const eqInner = vi.fn().mockResolvedValue({ error: { message: 'Update failed' } });
+      const eqOuter = vi.fn().mockReturnValue({ eq: eqInner });
+      const update = vi.fn().mockReturnValue({ eq: eqOuter });
+      vi.mocked(supabase.from).mockReturnValue({ update } as any);
+
+      await expect(pushService.unsubscribe(USER_ID, ENDPOINT)).rejects.toMatchObject({
+        code: 'DB_ERROR',
+      });
+    });
   });
 
   describe('getActiveSubscriptions', () => {

--- a/src/services/pushService.test.ts
+++ b/src/services/pushService.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/supabase/client', () => ({
+  supabase: {
+    auth: { getUser: vi.fn() },
+    from: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/push/encryption', () => ({
+  validatePushSubscriptionFields: vi.fn().mockReturnValue(null),
+}));
+
+import { pushService } from './pushService';
+import { supabase } from '@/lib/supabase/client';
+import { validatePushSubscriptionFields } from '@/lib/push/encryption';
+
+const USER_ID = 'user-1';
+const ENDPOINT = 'https://fcm.googleapis.com/push/abc';
+const P256DH = 'BNb2B0dAi8Q=';
+const AUTH = 'tBHItJI5svbpez7KI4CCXg==';
+
+const mockSubscription = {
+  id: 'sub-1',
+  user_id: USER_ID,
+  endpoint: ENDPOINT,
+  p256dh: P256DH,
+  auth: AUTH,
+  is_active: true,
+  created_at: '2026-04-19T00:00:00Z',
+  updated_at: '2026-04-19T00:00:00Z',
+};
+
+describe('pushService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(validatePushSubscriptionFields).mockReturnValue(null);
+  });
+
+  describe('subscribe', () => {
+    it('creates a push subscription successfully', async () => {
+      vi.mocked(supabase.auth.getUser).mockResolvedValue({
+        data: { user: { id: USER_ID } },
+        error: null,
+      } as any);
+
+      const mockChain = {
+        upsert: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: mockSubscription, error: null }),
+      };
+      vi.mocked(supabase.from).mockReturnValue(mockChain as any);
+
+      const result = await pushService.subscribe(USER_ID, {
+        endpoint: ENDPOINT,
+        p256dh: P256DH,
+        auth: AUTH,
+      });
+
+      expect(result).toEqual(mockSubscription);
+      expect(supabase.from).toHaveBeenCalledWith('push_subscriptions');
+    });
+
+    it('throws AUTH_ERROR when user is not authenticated', async () => {
+      vi.mocked(supabase.auth.getUser).mockResolvedValue({
+        data: { user: null },
+        error: new Error('Not authenticated'),
+      } as any);
+
+      await expect(
+        pushService.subscribe(USER_ID, { endpoint: ENDPOINT, p256dh: P256DH, auth: AUTH }),
+      ).rejects.toMatchObject({ code: 'AUTH_ERROR' });
+    });
+
+    it('throws AUTH_ERROR when userId does not match', async () => {
+      vi.mocked(supabase.auth.getUser).mockResolvedValue({
+        data: { user: { id: 'other-user' } },
+        error: null,
+      } as any);
+
+      await expect(
+        pushService.subscribe(USER_ID, { endpoint: ENDPOINT, p256dh: P256DH, auth: AUTH }),
+      ).rejects.toMatchObject({ code: 'AUTH_ERROR' });
+    });
+
+    it('throws VALIDATION_ERROR when fields are invalid', async () => {
+      vi.mocked(validatePushSubscriptionFields).mockReturnValue('endpoint は有効な HTTPS URL である必要があります。');
+      vi.mocked(supabase.auth.getUser).mockResolvedValue({
+        data: { user: { id: USER_ID } },
+        error: null,
+      } as any);
+
+      await expect(
+        pushService.subscribe(USER_ID, { endpoint: 'http://bad.com', p256dh: P256DH, auth: AUTH }),
+      ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+    });
+
+    it('throws DB_ERROR when database fails', async () => {
+      vi.mocked(supabase.auth.getUser).mockResolvedValue({
+        data: { user: { id: USER_ID } },
+        error: null,
+      } as any);
+
+      const mockChain = {
+        upsert: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: null, error: { message: 'DB error' } }),
+      };
+      vi.mocked(supabase.from).mockReturnValue(mockChain as any);
+
+      await expect(
+        pushService.subscribe(USER_ID, { endpoint: ENDPOINT, p256dh: P256DH, auth: AUTH }),
+      ).rejects.toMatchObject({ code: 'DB_ERROR' });
+    });
+  });
+
+  describe('unsubscribe', () => {
+    it('deactivates a subscription successfully', async () => {
+      vi.mocked(supabase.auth.getUser).mockResolvedValue({
+        data: { user: { id: USER_ID } },
+        error: null,
+      } as any);
+
+      const eqInner = vi.fn().mockResolvedValue({ error: null });
+      const eqOuter = vi.fn().mockReturnValue({ eq: eqInner });
+      const update = vi.fn().mockReturnValue({ eq: eqOuter });
+      vi.mocked(supabase.from).mockReturnValue({ update } as any);
+
+      await expect(pushService.unsubscribe(USER_ID, ENDPOINT)).resolves.toBeUndefined();
+    });
+
+    it('throws AUTH_ERROR when not authenticated', async () => {
+      vi.mocked(supabase.auth.getUser).mockResolvedValue({
+        data: { user: null },
+        error: new Error('Not authenticated'),
+      } as any);
+
+      await expect(pushService.unsubscribe(USER_ID, ENDPOINT)).rejects.toMatchObject({
+        code: 'AUTH_ERROR',
+      });
+    });
+  });
+
+  describe('getActiveSubscriptions', () => {
+    it('returns active subscriptions for the user', async () => {
+      vi.mocked(supabase.auth.getUser).mockResolvedValue({
+        data: { user: { id: USER_ID } },
+        error: null,
+      } as any);
+
+      const mockChain = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        order: vi.fn().mockResolvedValue({ data: [mockSubscription], error: null }),
+      };
+      vi.mocked(supabase.from).mockReturnValue(mockChain as any);
+
+      const result = await pushService.getActiveSubscriptions(USER_ID);
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('sub-1');
+    });
+
+    it('returns empty array when no subscriptions exist', async () => {
+      vi.mocked(supabase.auth.getUser).mockResolvedValue({
+        data: { user: { id: USER_ID } },
+        error: null,
+      } as any);
+
+      const mockChain = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        order: vi.fn().mockResolvedValue({ data: [], error: null }),
+      };
+      vi.mocked(supabase.from).mockReturnValue(mockChain as any);
+
+      const result = await pushService.getActiveSubscriptions(USER_ID);
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/services/pushService.test.ts
+++ b/src/services/pushService.test.ts
@@ -59,6 +59,18 @@ describe('pushService', () => {
 
       expect(result).toEqual(mockSubscription);
       expect(supabase.from).toHaveBeenCalledWith('push_subscriptions');
+      expect(mockChain.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user_id: USER_ID,
+          endpoint: ENDPOINT,
+          p256dh: P256DH,
+          auth: AUTH,
+          is_active: true,
+        }),
+        { onConflict: 'user_id,endpoint' },
+      );
+      expect(mockChain.select).toHaveBeenCalled();
+      expect(mockChain.single).toHaveBeenCalled();
     });
 
     it('throws AUTH_ERROR when user is not authenticated', async () => {
@@ -127,6 +139,9 @@ describe('pushService', () => {
       vi.mocked(supabase.from).mockReturnValue({ update } as any);
 
       await expect(pushService.unsubscribe(USER_ID, ENDPOINT)).resolves.toBeUndefined();
+      expect(update).toHaveBeenCalledWith({ is_active: false });
+      expect(eqOuter).toHaveBeenCalledWith('user_id', USER_ID);
+      expect(eqInner).toHaveBeenCalledWith('endpoint', ENDPOINT);
     });
 
     it('throws AUTH_ERROR when not authenticated', async () => {
@@ -174,6 +189,8 @@ describe('pushService', () => {
       const result = await pushService.getActiveSubscriptions(USER_ID);
       expect(result).toHaveLength(1);
       expect(result[0].id).toBe('sub-1');
+      expect(mockChain.eq).toHaveBeenCalledWith('is_active', true);
+      expect(mockChain.order).toHaveBeenCalledWith('created_at', { ascending: false });
     });
 
     it('returns empty array when no subscriptions exist', async () => {

--- a/src/services/pushService.ts
+++ b/src/services/pushService.ts
@@ -1,0 +1,91 @@
+import { supabase } from '@/lib/supabase/client';
+import { validatePushSubscriptionFields } from '@/lib/push/encryption';
+import type {
+  PushSubscription,
+  CreatePushSubscriptionRequest,
+} from '@/types/push';
+
+export const pushService = {
+  async subscribe(
+    userId: string,
+    request: CreatePushSubscriptionRequest,
+  ): Promise<PushSubscription> {
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user || user.id !== userId) {
+      throw { code: 'AUTH_ERROR', message: '認証されていません。ログインしてください。' };
+    }
+
+    const validationError = validatePushSubscriptionFields(
+      request.endpoint,
+      request.p256dh,
+      request.auth,
+    );
+    if (validationError) {
+      throw { code: 'VALIDATION_ERROR', message: validationError };
+    }
+
+    const { data, error } = await supabase
+      .from('push_subscriptions')
+      .upsert(
+        {
+          user_id: userId,
+          endpoint: request.endpoint,
+          p256dh: request.p256dh,
+          auth: request.auth,
+          user_agent: request.user_agent,
+          browser: request.browser,
+          is_active: true,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'user_id,endpoint' },
+      )
+      .select()
+      .single();
+
+    if (error) {
+      throw { code: 'DB_ERROR', message: error.message };
+    }
+
+    return data as PushSubscription;
+  },
+
+  async unsubscribe(userId: string, endpoint: string): Promise<void> {
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user || user.id !== userId) {
+      throw { code: 'AUTH_ERROR', message: '認証されていません。ログインしてください。' };
+    }
+
+    const { error } = await supabase
+      .from('push_subscriptions')
+      .update({ is_active: false, updated_at: new Date().toISOString() })
+      .eq('user_id', userId)
+      .eq('endpoint', endpoint);
+
+    if (error) {
+      throw { code: 'DB_ERROR', message: error.message };
+    }
+  },
+
+  async getActiveSubscriptions(userId: string): Promise<PushSubscription[]> {
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user || user.id !== userId) {
+      throw { code: 'AUTH_ERROR', message: '認証されていません。ログインしてください。' };
+    }
+
+    const { data, error } = await supabase
+      .from('push_subscriptions')
+      .select('*')
+      .eq('user_id', userId)
+      .eq('is_active', true)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      throw { code: 'DB_ERROR', message: error.message };
+    }
+
+    return (data || []) as PushSubscription[];
+  },
+};

--- a/src/services/pushService.ts
+++ b/src/services/pushService.ts
@@ -36,7 +36,6 @@ export const pushService = {
           user_agent: request.user_agent,
           browser: request.browser,
           is_active: true,
-          updated_at: new Date().toISOString(),
         },
         { onConflict: 'user_id,endpoint' },
       )
@@ -59,7 +58,7 @@ export const pushService = {
 
     const { error } = await supabase
       .from('push_subscriptions')
-      .update({ is_active: false, updated_at: new Date().toISOString() })
+      .update({ is_active: false })
       .eq('user_id', userId)
       .eq('endpoint', endpoint);
 

--- a/src/types/push.ts
+++ b/src/types/push.ts
@@ -1,0 +1,43 @@
+export interface PushSubscription {
+  id: string;
+  user_id: string;
+  endpoint: string;
+  p256dh: string;
+  auth: string;
+  user_agent?: string;
+  browser?: string;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreatePushSubscriptionRequest {
+  endpoint: string;
+  p256dh: string;
+  auth: string;
+  user_agent?: string;
+  browser?: string;
+}
+
+export interface NotificationPreferences {
+  daily_reminder: boolean;
+  reminder_time?: string; // HH:MM format
+  weekly_summary: boolean;
+  achievement_alerts: boolean;
+}
+
+export interface UserPreferences {
+  id: string;
+  user_id: string;
+  pwa_install_dismissed: boolean;
+  timezone: string;
+  notification_preferences: NotificationPreferences;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface UpdateUserPreferencesRequest {
+  pwa_install_dismissed?: boolean;
+  timezone?: string;
+  notification_preferences?: Partial<NotificationPreferences>;
+}


### PR DESCRIPTION
## 概要

Closes #69

Phase 3 での Web プッシュ通知実装に向けた基盤を構築しました。データモデル設計・API エンドポイント・暗号化ロジック・ユニットテストをすべて実装しています。

## 実装内容

### 型定義
- `src/types/push.ts` — `PushSubscription` / `UserPreferences` / `NotificationPreferences` 型

### データベース
- `database/push-subscriptions-and-preferences.sql`
  - `push_subscriptions` テーブル（`id`, `user_id`, `endpoint`, `p256dh`, `auth`, `user_agent`, `browser`, `is_active`, `created_at`, `updated_at`）
  - `user_preferences` テーブル（`pwa_install_dismissed`, `timezone`, `notification_preferences` JSON）
  - 各テーブルに RLS ポリシー設定・`updated_at` 自動更新トリガー

### セキュリティ / 暗号化
- `src/lib/push/encryption.ts`
  - endpoint の SHA-256 ハッシュ化（ログ安全化）
  - HTTPS endpoint バリデーション
  - Base64url 形式バリデーション
  - 購読フィールド一括検証

### サービス層
- `src/services/pushService.ts` — `subscribe` / `unsubscribe` / `getActiveSubscriptions`
- `src/services/preferencesService.ts` — `getPreferences` / `updatePreferences`（未存在時はデフォルト値で自動作成）

### API エンドポイント
- `POST /api/push/subscribe` — Push Subscription 登録（upsert）
- `POST /api/push/unsubscribe` — Push Subscription 非アクティブ化
- `GET /api/preferences` — ユーザー設定取得（未存在時は自動作成）
- `PUT /api/preferences` — ユーザー設定更新（notification_preferences はマージ）

### テスト
| ファイル | テスト数 |
|---|---|
| `src/lib/push/encryption.test.ts` | 15 |
| `src/services/pushService.test.ts` | 10 |
| `src/services/preferencesService.test.ts` | 6 |
| `src/app/api/push/subscribe/route.test.ts` | 5 |
| `src/app/api/push/unsubscribe/route.test.ts` | 4 |
| `src/app/api/preferences/route.test.ts` | 8 |
| **合計** | **48** |

## テスト計画

- [x] `pnpm test:run` で新規追加 48 テストすべて通過確認済み
- [x] 既存テスト（409 tests）への影響なし
- [ ] Supabase ダッシュボードで `push-subscriptions-and-preferences.sql` を実行してテーブル作成

## チェックリスト

- [x] Push Subscriptions テーブル実装
- [x] User Preferences テーブル実装
- [x] Push API エンドポイント設計完了
- [x] 暗号化ロジック実装
- [x] ユニットテスト実装
- [x] 全テスト通過確認

https://claude.ai/code/session_01TtcB9xj6aowbN4RDFUwsv6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Push subscription management: subscribe, unsubscribe, and list active subscriptions with validation and secure per-user storage
  * User preferences API: get and update preferences (timezone, PWA install dismissal, nested notification settings) with sensible defaults and merge-on-update

* **Tests**
  * Added comprehensive tests covering push flows, preferences CRUD/merge, validation, and related utilities
<!-- end of auto-generated comment: release notes by coderabbit.ai -->