### PR TITLE
feat(#72): GrowthTrendChart で3ヶ月の累積成長を可視化

### DIFF
--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -19,6 +19,7 @@ import PeriodComparison from '@/components/statistics/PeriodComparison';
 import StreakDisplay from '@/components/statistics/StreakDisplay';
 import ActivityHeatmap from '@/components/statistics/ActivityHeatmap';
 import ThisWeekStatus from '@/components/statistics/ThisWeekStatus';
+import GrowthTrendChart from '@/components/statistics/GrowthTrendChart';
 
 export default function AnalyticsPage() {
   const { user, signOut, isLoading: authLoading } = useAuth();
@@ -146,6 +147,10 @@ export default function AnalyticsPage() {
               <div className="lg:col-span-2">
                 <ActivityHeatmap heatmap={summary.weeklyHeatmap} />
               </div>
+            </section>
+
+            <section>
+              <GrowthTrendChart trends={trends} />
             </section>
 
             <section>

--- a/src/components/statistics/GrowthTrendChart.test.tsx
+++ b/src/components/statistics/GrowthTrendChart.test.tsx
@@ -1,9 +1,23 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import GrowthTrendChart from './GrowthTrendChart';
 import type { AnalyticsTrends, TrendPoint } from '@/types/analytics';
 
+let originalClientWidth: PropertyDescriptor | undefined;
+let originalClientHeight: PropertyDescriptor | undefined;
+const originalResizeObserver = globalThis.ResizeObserver;
+let didStubResizeObserver = false;
+
 beforeAll(() => {
+  originalClientWidth = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    'clientWidth',
+  );
+  originalClientHeight = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    'clientHeight',
+  );
+
   // Recharts' ResponsiveContainer relies on these to render in jsdom.
   Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
     configurable: true,
@@ -19,6 +33,23 @@ beforeAll(() => {
       unobserve() {}
       disconnect() {}
     } as typeof ResizeObserver;
+    didStubResizeObserver = true;
+  }
+});
+
+afterAll(() => {
+  if (originalClientWidth) {
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', originalClientWidth);
+  } else {
+    delete (HTMLElement.prototype as unknown as Record<string, unknown>).clientWidth;
+  }
+  if (originalClientHeight) {
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', originalClientHeight);
+  } else {
+    delete (HTMLElement.prototype as unknown as Record<string, unknown>).clientHeight;
+  }
+  if (didStubResizeObserver) {
+    globalThis.ResizeObserver = originalResizeObserver;
   }
 });
 

--- a/src/components/statistics/GrowthTrendChart.test.tsx
+++ b/src/components/statistics/GrowthTrendChart.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import GrowthTrendChart from './GrowthTrendChart';
+import type { AnalyticsTrends, TrendPoint } from '@/types/analytics';
+
+beforeAll(() => {
+  // Recharts' ResponsiveContainer relies on these to render in jsdom.
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+    configurable: true,
+    value: 400,
+  });
+  Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+    configurable: true,
+    value: 256,
+  });
+  if (typeof globalThis.ResizeObserver === 'undefined') {
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as typeof ResizeObserver;
+  }
+});
+
+const point = (period: string, count: number): TrendPoint => ({
+  period,
+  count,
+  characters: count * 100,
+});
+
+const buildTrends = (monthly: TrendPoint[]): AnalyticsTrends => ({
+  weekly: [],
+  monthly,
+});
+
+describe('GrowthTrendChart', () => {
+  it('renders title with the configured month window', () => {
+    const trends = buildTrends([
+      point('2026-03', 1),
+      point('2026-04', 2),
+      point('2026-05', 3),
+    ]);
+
+    render(<GrowthTrendChart trends={trends} />);
+
+    expect(screen.getByText('3ヶ月の成長')).toBeInTheDocument();
+  });
+
+  it('summarises additions across the displayed window', () => {
+    const trends = buildTrends([
+      point('2026-01', 5), // outside default 3-month window
+      point('2026-02', 5), // outside default 3-month window
+      point('2026-03', 1),
+      point('2026-04', 2),
+      point('2026-05', 3),
+    ]);
+
+    render(<GrowthTrendChart trends={trends} />);
+
+    // Summary should include only the last 3 months: 1 + 2 + 3 = 6
+    expect(screen.getByText('6')).toBeInTheDocument();
+    expect(screen.getByText(/直近3ヶ月で/)).toBeInTheDocument();
+  });
+
+  it('honours a custom months window', () => {
+    const trends = buildTrends([
+      point('2026-03', 1),
+      point('2026-04', 2),
+      point('2026-05', 3),
+    ]);
+
+    render(<GrowthTrendChart trends={trends} months={2} />);
+
+    expect(screen.getByText('2ヶ月の成長')).toBeInTheDocument();
+    // 2 + 3 = 5 over the last 2 months
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  it('renders without crashing when monthly data is empty', () => {
+    const trends = buildTrends([]);
+    render(<GrowthTrendChart trends={trends} />);
+    expect(screen.getByText('3ヶ月の成長')).toBeInTheDocument();
+    expect(screen.getByText('0')).toBeInTheDocument();
+  });
+});

--- a/src/components/statistics/GrowthTrendChart.test.tsx
+++ b/src/components/statistics/GrowthTrendChart.test.tsx
@@ -58,8 +58,9 @@ describe('GrowthTrendChart', () => {
     render(<GrowthTrendChart trends={trends} />);
 
     // Summary should include only the last 3 months: 1 + 2 + 3 = 6
-    expect(screen.getByText('6')).toBeInTheDocument();
-    expect(screen.getByText(/直近3ヶ月で/)).toBeInTheDocument();
+    expect(
+      screen.getByText((_, node) => node?.textContent === '直近3ヶ月で 6 件'),
+    ).toBeInTheDocument();
   });
 
   it('honours a custom months window', () => {
@@ -73,13 +74,45 @@ describe('GrowthTrendChart', () => {
 
     expect(screen.getByText('2ヶ月の成長')).toBeInTheDocument();
     // 2 + 3 = 5 over the last 2 months
-    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(
+      screen.getByText((_, node) => node?.textContent === '直近2ヶ月で 5 件'),
+    ).toBeInTheDocument();
   });
 
   it('renders without crashing when monthly data is empty', () => {
     const trends = buildTrends([]);
     render(<GrowthTrendChart trends={trends} />);
     expect(screen.getByText('3ヶ月の成長')).toBeInTheDocument();
-    expect(screen.getByText('0')).toBeInTheDocument();
+    expect(
+      screen.getByText((_, node) => node?.textContent === '直近3ヶ月で 0 件'),
+    ).toBeInTheDocument();
+  });
+
+  it('normalises non-positive or non-integer months to the default window', () => {
+    const trends = buildTrends([
+      point('2026-01', 5),
+      point('2026-02', 5),
+      point('2026-03', 1),
+      point('2026-04', 2),
+      point('2026-05', 3),
+    ]);
+
+    // months=0 must NOT produce slice(-0) (which returns the full array).
+    const { rerender } = render(<GrowthTrendChart trends={trends} months={0} />);
+    expect(screen.getByText('3ヶ月の成長')).toBeInTheDocument();
+    expect(
+      screen.getByText((_, node) => node?.textContent === '直近3ヶ月で 6 件'),
+    ).toBeInTheDocument();
+
+    // Negative values fall back to the default too.
+    rerender(<GrowthTrendChart trends={trends} months={-2} />);
+    expect(screen.getByText('3ヶ月の成長')).toBeInTheDocument();
+
+    // Fractional values are floored to the nearest positive integer.
+    rerender(<GrowthTrendChart trends={trends} months={2.7} />);
+    expect(screen.getByText('2ヶ月の成長')).toBeInTheDocument();
+    expect(
+      screen.getByText((_, node) => node?.textContent === '直近2ヶ月で 5 件'),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/statistics/GrowthTrendChart.tsx
+++ b/src/components/statistics/GrowthTrendChart.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useMemo } from 'react';
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { AnalyticsTrends } from '@/types/analytics';
+
+export interface GrowthTrendChartProps {
+  trends: AnalyticsTrends;
+  months?: number;
+}
+
+const DEFAULT_MONTHS = 3;
+
+export default function GrowthTrendChart({
+  trends,
+  months = DEFAULT_MONTHS,
+}: GrowthTrendChartProps) {
+  const data = useMemo(() => {
+    const recent = trends.monthly.slice(-months);
+    let cumulative = 0;
+    return recent.map((point) => {
+      cumulative += point.count;
+      return {
+        label: point.period,
+        cumulative,
+        added: point.count,
+      };
+    });
+  }, [trends, months]);
+
+  const totalAdded = data.reduce((sum, point) => sum + point.added, 0);
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between pb-2">
+        <CardTitle className="text-lg">{months}ヶ月の成長</CardTitle>
+        <p className="text-sm text-gray-500">
+          直近{months}ヶ月で <span className="font-semibold text-gray-900">{totalAdded}</span> 件
+        </p>
+      </CardHeader>
+      <CardContent>
+        <div className="h-64 w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <AreaChart data={data} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
+              <defs>
+                <linearGradient id="growthGradient" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor="#10b981" stopOpacity={0.45} />
+                  <stop offset="100%" stopColor="#10b981" stopOpacity={0.05} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+              <XAxis
+                dataKey="label"
+                tick={{ fontSize: 12, fill: '#6b7280' }}
+                interval="preserveStartEnd"
+              />
+              <YAxis
+                allowDecimals={false}
+                tick={{ fontSize: 12, fill: '#6b7280' }}
+                width={32}
+              />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: '#ffffff',
+                  border: '1px solid #e5e7eb',
+                  borderRadius: '0.5rem',
+                }}
+                formatter={(value, name) => {
+                  if (name === 'cumulative') return [`${value} 件`, '累積振り返り数'];
+                  if (name === 'added') return [`${value} 件`, '当月の追加'];
+                  return [String(value), String(name)];
+                }}
+              />
+              <Area
+                type="monotone"
+                dataKey="cumulative"
+                stroke="#10b981"
+                strokeWidth={2}
+                fill="url(#growthGradient)"
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/statistics/GrowthTrendChart.tsx
+++ b/src/components/statistics/GrowthTrendChart.tsx
@@ -24,8 +24,11 @@ export default function GrowthTrendChart({
   trends,
   months = DEFAULT_MONTHS,
 }: GrowthTrendChartProps) {
+  const normalizedMonths =
+    Number.isFinite(months) && months > 0 ? Math.floor(months) : DEFAULT_MONTHS;
+
   const data = useMemo(() => {
-    const recent = trends.monthly.slice(-months);
+    const recent = trends.monthly.slice(-normalizedMonths);
     let cumulative = 0;
     return recent.map((point) => {
       cumulative += point.count;
@@ -35,16 +38,16 @@ export default function GrowthTrendChart({
         added: point.count,
       };
     });
-  }, [trends, months]);
+  }, [trends, normalizedMonths]);
 
   const totalAdded = data.reduce((sum, point) => sum + point.added, 0);
 
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between pb-2">
-        <CardTitle className="text-lg">{months}ヶ月の成長</CardTitle>
+        <CardTitle className="text-lg">{normalizedMonths}ヶ月の成長</CardTitle>
         <p className="text-sm text-gray-500">
-          直近{months}ヶ月で <span className="font-semibold text-gray-900">{totalAdded}</span> 件
+          直近{normalizedMonths}ヶ月で <span className="font-semibold text-gray-900">{totalAdded}</span> 件
         </p>
       </CardHeader>
       <CardContent>


### PR DESCRIPTION
## Summary

issue #72 の未実装項目「GrowthTrendChart.tsx - Area Chart（3ヶ月成長）」を実装します。

統計ダッシュボードに、直近3ヶ月の累積振り返り数を Area Chart で可視化する `GrowthTrendChart` を追加しました。既存の `trends.monthly` データから派生計算するため、API 変更は不要です。

## Changes

- `src/components/statistics/GrowthTrendChart.tsx`
  - Recharts `AreaChart` で累積件数の推移を描画
  - `months` prop で表示期間をカスタマイズ可能（デフォルト 3）
  - ヘッダーに「直近 N ヶ月で X 件」のサマリー表示
  - グラデーション塗りつぶしと既存 Card UI に揃えたスタイル
- `src/components/statistics/GrowthTrendChart.test.tsx`
  - タイトル / サマリー / カスタム期間 / 空データのレンダリングを検証（4 ケース）
- `src/app/analytics/page.tsx`
  - StreakDisplay + ActivityHeatmap の下、FrameworkBreakdown の上に配置

## 関連 Issue 進捗

issue #72 のチェックリストのうち、本 PR で「GrowthTrendChart」の項目を完了します。残りの未実装項目（EmotionalTrend）は、現状 `mood` データが UI から入力されないため対象外と判断しました。

## Test plan

- [x] `pnpm vitest run src/components/statistics/GrowthTrendChart.test.tsx` が通る（4/4）
- [x] `pnpm vitest run src/components/statistics/ src/services/analyticsService.test.ts` が通る（45/45）
- [x] 追加ファイルに lint エラーなし
- [x] 追加ファイルに TypeScript エラーなし
- [ ] ブラウザで `/analytics` を開いて Area Chart が表示されることを確認
- [ ] レスポンシブ（モバイル幅）でレイアウト崩れがないことを確認

Closes #72 の一部

https://claude.ai/code/session_01CFXum283FzwBoQfh68PLAA

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFXum283FzwBoQfh68PLAA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a Growth Trend Chart on the Analytics page showing cumulative totals and period-over-period growth over a configurable time window (default 3 months).
* **Tests**
  * Added test coverage verifying rendering, windowing behavior, totals calculation, edge-case handling for non-positive/fractional windows, and empty data display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->