### PR TITLE
Improve iOS PWA installation instructions with clearer steps

### DIFF
--- a/src/components/common/InstallPrompt.tsx
+++ b/src/components/common/InstallPrompt.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Download, Plus, Share, X } from 'lucide-react';
+import { Check, Download, Plus, Share, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useInstallPrompt } from '@/hooks/useInstallPrompt';
 
@@ -105,24 +105,35 @@ export function InstallPrompt({ disabled = false }: InstallPromptProps) {
             >
               アプリのように起動できます。下記の手順で追加してください。
             </p>
-            <ol className="space-y-1 pt-2 text-sm text-muted-foreground">
-              <li className="flex items-center gap-2">
-                <span>1.</span>
+            <ol className="space-y-1.5 pt-2 text-sm text-muted-foreground">
+              <li className="flex items-start gap-2">
+                <span className="shrink-0">1.</span>
                 <Share
-                  className="h-4 w-4 text-foreground"
+                  className="mt-0.5 h-4 w-4 shrink-0 text-foreground"
                   aria-hidden="true"
                 />
-                <span>画面下の「共有」ボタンをタップ</span>
+                <span>アドレスバーまたはツールバーの「共有」ボタンをタップ</span>
               </li>
-              <li className="flex items-center gap-2">
-                <span>2.</span>
+              <li className="flex items-start gap-2">
+                <span className="shrink-0">2.</span>
                 <Plus
-                  className="h-4 w-4 text-foreground"
+                  className="mt-0.5 h-4 w-4 shrink-0 text-foreground"
                   aria-hidden="true"
                 />
-                <span>「ホーム画面に追加」を選択</span>
+                <span>メニューを下にスクロールし「ホーム画面に追加」を選択</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="shrink-0">3.</span>
+                <Check
+                  className="mt-0.5 h-4 w-4 shrink-0 text-foreground"
+                  aria-hidden="true"
+                />
+                <span>右上の「追加」をタップして完了</span>
               </li>
             </ol>
+            <p className="pt-2 text-xs text-muted-foreground">
+              ※ うまくいかない場合は Safari で開いてからお試しください。
+            </p>
           </div>
           <button
             type="button"


### PR DESCRIPTION
## 概要
iOS デバイスでのホーム画面追加手順をより詳細で分かりやすくするため、InstallPrompt コンポーネントの説明文を改善しました。

## 変更内容
- Check アイコンを lucide-react からインポート
- iOS インストール手順を 2 ステップから 3 ステップに拡張
  - ステップ 1: 「共有」ボタンの位置を明確化（アドレスバーまたはツールバー）
  - ステップ 2: メニュースクロール手順を追加
  - ステップ 3: 「追加」ボタンをタップして完了する手順を新規追加
- リスト項目のアライメントを `items-center` から `items-start` に変更
- アイコンに `mt-0.5` と `shrink-0` クラスを追加してテキストとの配置を改善
- リスト項目間のスペーシングを `space-y-1` から `space-y-1.5` に拡大
- Safari での代替手順に関する注釈を追加

## 動機・背景
ユーザーが iOS デバイスでアプリをホーム画面に追加する際の手順が不明確だったため、より詳細で段階的な説明に改善しました。また、うまくいかない場合の代替手段（Safari での実行）についても記載しました。

## テスト
- [ ] 手動テスト（iOS Safari での表示確認）

## チェックリスト
- [ ] pnpm lint:fixを行った
- [ ] CodeRabbitで問題がない
- [ ] `pnpm run build`で問題が出ない
- [ ] Vercel botで問題が出ない

https://claude.ai/code/session_01TDXgK8ryRnQKqHfkkkYfND

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Enhanced iOS "Add to Home Screen" installation instructions with expanded steps, clearer visual layout, and additional guidance for Safari users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->