### PR TITLE
feat(#92): CSRF middleware 統合 + zod 入力検証 + URL/サニタイズ強化

### DIFF
--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -13,17 +13,25 @@ vi.mock('@supabase/ssr', () => ({
 import { generateCSRFToken, CSRF_COOKIE_NAME, CSRF_HEADER_NAME } from '@/utils/csrfToken';
 import { middleware } from './middleware';
 
-const ORIGINAL_SECRET = process.env.CSRF_SECRET;
+const MUTATED_ENV_KEYS = [
+  'CSRF_SECRET',
+  'NEXT_PUBLIC_SUPABASE_URL',
+  'NEXT_PUBLIC_SUPABASE_ANON_KEY',
+] as const;
+const ORIGINAL_ENV: Record<string, string | undefined> = {};
 
 beforeAll(() => {
+  for (const k of MUTATED_ENV_KEYS) ORIGINAL_ENV[k] = process.env[k];
   process.env.CSRF_SECRET = 'test-secret-for-middleware-1234567890';
   process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://supabase.test';
   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon';
 });
 
 afterAll(() => {
-  if (ORIGINAL_SECRET === undefined) delete process.env.CSRF_SECRET;
-  else process.env.CSRF_SECRET = ORIGINAL_SECRET;
+  for (const k of MUTATED_ENV_KEYS) {
+    if (ORIGINAL_ENV[k] === undefined) delete process.env[k];
+    else process.env[k] = ORIGINAL_ENV[k];
+  }
 });
 
 beforeEach(() => {

--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// Supabase モック (CSRF 経路に到達できれば中身は問わない)。
+vi.mock('@supabase/ssr', () => ({
+  createServerClient: vi.fn(() => ({
+    auth: {
+      getSession: vi.fn().mockResolvedValue({ data: { session: null }, error: null }),
+    },
+  })),
+}));
+
+import { generateCSRFToken, CSRF_COOKIE_NAME, CSRF_HEADER_NAME } from '@/utils/csrfToken';
+import { middleware } from './middleware';
+
+const ORIGINAL_SECRET = process.env.CSRF_SECRET;
+
+beforeAll(() => {
+  process.env.CSRF_SECRET = 'test-secret-for-middleware-1234567890';
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://supabase.test';
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon';
+});
+
+afterAll(() => {
+  if (ORIGINAL_SECRET === undefined) delete process.env.CSRF_SECRET;
+  else process.env.CSRF_SECRET = ORIGINAL_SECRET;
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function makeRequest(opts: {
+  pathname: string;
+  method: string;
+  csrfHeader?: string;
+  csrfCookie?: string;
+}): NextRequest {
+  const url = `http://localhost${opts.pathname}`;
+  const headers = new Headers();
+  if (opts.csrfHeader) headers.set(CSRF_HEADER_NAME, opts.csrfHeader);
+  const req = new NextRequest(url, { method: opts.method, headers });
+  if (opts.csrfCookie) {
+    req.cookies.set(CSRF_COOKIE_NAME, opts.csrfCookie);
+  }
+  return req;
+}
+
+describe('middleware CSRF enforcement', () => {
+  it('blocks POST /api/preferences without CSRF token (403)', async () => {
+    const res = await middleware(
+      makeRequest({ pathname: '/api/preferences', method: 'POST' }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('blocks PUT with mismatched header/cookie (403)', async () => {
+    const a = generateCSRFToken();
+    const b = generateCSRFToken();
+    const res = await middleware(
+      makeRequest({
+        pathname: '/api/preferences',
+        method: 'PUT',
+        csrfHeader: a,
+        csrfCookie: b,
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('blocks DELETE with tampered signature (403)', async () => {
+    const t = generateCSRFToken();
+    const tampered = `${t.split('.')[0]}.deadbeef`;
+    const res = await middleware(
+      makeRequest({
+        pathname: '/api/preferences',
+        method: 'DELETE',
+        csrfHeader: tampered,
+        csrfCookie: tampered,
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('allows POST with matching valid CSRF token', async () => {
+    const t = generateCSRFToken();
+    const res = await middleware(
+      makeRequest({
+        pathname: '/api/preferences',
+        method: 'POST',
+        csrfHeader: t,
+        csrfCookie: t,
+      }),
+    );
+    // 200 系 or リダイレクト (NextResponse.next())。403 でない事を確認すれば十分。
+    expect(res.status).not.toBe(403);
+  });
+
+  it('allows GET without CSRF token', async () => {
+    const res = await middleware(
+      makeRequest({ pathname: '/api/preferences', method: 'GET' }),
+    );
+    expect(res.status).not.toBe(403);
+  });
+
+  it('exempts /api/csrf', async () => {
+    const res = await middleware(
+      makeRequest({ pathname: '/api/csrf', method: 'POST' }),
+    );
+    expect(res.status).not.toBe(403);
+  });
+
+  it('exempts /api/auth/callback', async () => {
+    const res = await middleware(
+      makeRequest({ pathname: '/api/auth/callback', method: 'POST' }),
+    );
+    expect(res.status).not.toBe(403);
+  });
+
+  it('exempts /api/cron/*', async () => {
+    const res = await middleware(
+      makeRequest({ pathname: '/api/cron/daily-reminder', method: 'POST' }),
+    );
+    expect(res.status).not.toBe(403);
+  });
+
+  it('does not enforce CSRF on non-API mutating requests (e.g. /something POST)', async () => {
+    const res = await middleware(
+      makeRequest({ pathname: '/dashboard', method: 'POST' }),
+    );
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,10 @@
 import { createServerClient, type CookieOptions } from '@supabase/ssr';
 import { NextResponse, type NextRequest } from 'next/server';
-import { CSRF_COOKIE_NAME, CSRF_HEADER_NAME } from '@/utils/csrfToken';
-import { verifyCSRFAsync } from '@/utils/csrfTokenEdge';
+import {
+  CSRF_COOKIE_NAME,
+  CSRF_HEADER_NAME,
+  verifyCSRFAsync,
+} from '@/utils/csrfTokenEdge';
 
 const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
 
@@ -10,11 +13,15 @@ const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
  * - `/api/csrf`: トークン発行エンドポイント (GET のみだが念のため)
  * - `/api/auth/callback`: OAuth プロバイダからのコールバック (CSRF と無関係)
  * - `/api/cron/*`: Vercel Cron からの呼び出し。`Authorization: Bearer ${CRON_SECRET}` で別途認証
+ * - `/api/logs/errors`: クライアント側エラーロギング。`navigator.sendBeacon` から
+ *   呼ばれるとカスタムヘッダを付与できないため CSRF 強制は外す。サーバ側で
+ *   `user_id` をセッションから決定し、ボディの値を信用しない実装になっている。
  */
 const CSRF_EXEMPT_PATHS: ReadonlyArray<string> = [
   '/api/csrf',
   '/api/auth/callback',
   '/api/cron/',
+  '/api/logs/errors',
 ];
 
 function isCSRFExempt(pathname: string): boolean {

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,49 @@
 import { createServerClient, type CookieOptions } from '@supabase/ssr';
 import { NextResponse, type NextRequest } from 'next/server';
+import { CSRF_COOKIE_NAME, CSRF_HEADER_NAME } from '@/utils/csrfToken';
+import { verifyCSRFAsync } from '@/utils/csrfTokenEdge';
+
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+/**
+ * CSRF 検証を免除するパス。
+ * - `/api/csrf`: トークン発行エンドポイント (GET のみだが念のため)
+ * - `/api/auth/callback`: OAuth プロバイダからのコールバック (CSRF と無関係)
+ * - `/api/cron/*`: Vercel Cron からの呼び出し。`Authorization: Bearer ${CRON_SECRET}` で別途認証
+ */
+const CSRF_EXEMPT_PATHS: ReadonlyArray<string> = [
+  '/api/csrf',
+  '/api/auth/callback',
+  '/api/cron/',
+];
+
+function isCSRFExempt(pathname: string): boolean {
+  return CSRF_EXEMPT_PATHS.some((p) =>
+    p.endsWith('/') ? pathname.startsWith(p) : pathname === p,
+  );
+}
 
 export async function middleware(request: NextRequest) {
+  // /api/* かつ mutation メソッドの場合は CSRF を先に検証する。
+  // Supabase セッション初期化より前に走らせて、未認証でも同じ 403 で弾く。
+  const pathname = request.nextUrl.pathname;
+  if (
+    pathname.startsWith('/api/') &&
+    MUTATING_METHODS.has(request.method) &&
+    !isCSRFExempt(pathname)
+  ) {
+    const result = await verifyCSRFAsync(
+      request.headers.get(CSRF_HEADER_NAME),
+      request.cookies.get(CSRF_COOKIE_NAME)?.value ?? null,
+    );
+    if (!result.ok) {
+      return NextResponse.json(
+        { error: 'CSRF validation failed', reason: result.reason },
+        { status: 403 },
+      );
+    }
+  }
+
   let response = NextResponse.next({
     request: {
       headers: request.headers,
@@ -10,7 +52,7 @@ export async function middleware(request: NextRequest) {
 
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-  
+
   if (!supabaseUrl || !supabaseAnonKey) {
     console.error('Missing Supabase environment variables in middleware');
     return response;

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "recharts": "^3.8.1",
     "tailwind-merge": "^3.3.1",
     "uuid": "^13.0.0",
+    "zod": "^4.4.3",
     "zustand": "^5.0.8"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
         version: 16.0.7(@babel/core@7.28.5)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       openai:
         specifier: ^5.16.0
-        version: 5.23.2(ws@8.18.3)
+        version: 5.23.2(ws@8.18.3)(zod@4.4.3)
       react:
         specifier: 19.1.4
         version: 19.1.4
@@ -83,6 +83,9 @@ importers:
       uuid:
         specifier: ^13.0.0
         version: 13.0.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
       zustand:
         specifier: ^5.0.8
         version: 5.0.8(@types/react@19.2.4)(immer@11.1.4)(react@19.1.4)(use-sync-external-store@1.6.0(react@19.1.4))
@@ -3664,6 +3667,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
   zustand@5.0.8:
     resolution: {integrity: sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==}
     engines: {node: '>=12.20.0'}
@@ -6409,9 +6415,10 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
-  openai@5.23.2(ws@8.18.3):
+  openai@5.23.2(ws@8.18.3)(zod@4.4.3):
     optionalDependencies:
       ws: 8.18.3
+      zod: 4.4.3
 
   optionator@0.9.4:
     dependencies:
@@ -7182,6 +7189,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@4.4.3: {}
 
   zustand@5.0.8(@types/react@19.2.4)(immer@11.1.4)(react@19.1.4)(use-sync-external-store@1.6.0(react@19.1.4)):
     optionalDependencies:

--- a/src/app/api/auth/profile/[userId]/route.test.ts
+++ b/src/app/api/auth/profile/[userId]/route.test.ts
@@ -262,7 +262,7 @@ describe('Profile API Route', () => {
       const data = await response.json();
 
       expect(response.status).toBe(400);
-      expect(data.error).toBe('Name is required');
+      expect(typeof data.error).toBe('string');
     });
 
     it('should return 400 when name is whitespace only', async () => {
@@ -286,7 +286,7 @@ describe('Profile API Route', () => {
       const data = await response.json();
 
       expect(response.status).toBe(400);
-      expect(data.error).toBe('Name is required');
+      expect(typeof data.error).toBe('string');
     });
 
     it('should return 401 when not authenticated', async () => {

--- a/src/app/api/auth/profile/[userId]/route.ts
+++ b/src/app/api/auth/profile/[userId]/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createServerClient, type CookieOptions } from '@supabase/ssr';
 import { cookies } from 'next/headers';
+import { ProfileUpdateSchema } from '@/lib/validation/schemas';
+import { parseJsonBody } from '@/lib/validation/parse';
+import { sanitizePlainText } from '@/utils/sanitize';
 
 export async function GET(
   request: NextRequest,
@@ -156,20 +159,17 @@ export async function PATCH(
       );
     }
 
-    const body = await request.json();
-    const { name } = body;
-
-    if (!name || typeof name !== 'string' || name.trim().length === 0) {
-      return NextResponse.json(
-        { error: 'Name is required' },
-        { status: 400 }
-      );
+    const parsed = await parseJsonBody(request, ProfileUpdateSchema);
+    if (!parsed.ok) return parsed.response;
+    const safeName = sanitizePlainText(parsed.data.name);
+    if (safeName.length === 0) {
+      return NextResponse.json({ error: 'Name is required' }, { status: 400 });
     }
 
     const { data: updatedProfile, error: updateError } = await supabase
       .from('profiles')
       .update({
-        name: name.trim(),
+        name: safeName,
         updated_at: new Date().toISOString(),
       })
       .eq('id', userId)

--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -1,18 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createServerClient, type CookieOptions } from '@supabase/ssr';
 import { cookies } from 'next/headers';
+import { SessionCreateSchema } from '@/lib/validation/schemas';
+import { parseJsonBody } from '@/lib/validation/parse';
+import { sanitizePlainText } from '@/utils/sanitize';
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
-    const { access_token, refresh_token } = body;
-
-    if (!access_token || !refresh_token) {
-      return NextResponse.json(
-        { error: 'Missing tokens' },
-        { status: 400 }
-      );
-    }
+    const parsed = await parseJsonBody(request, SessionCreateSchema);
+    if (!parsed.ok) return parsed.response;
+    const { access_token, refresh_token } = parsed.data;
 
     const response = NextResponse.json({ success: true });
     const cookieStore = await cookies();
@@ -66,9 +63,12 @@ export async function POST(request: NextRequest) {
           .eq('id', data.session.user.id)
           .single();
 
-        const googleName = data.session.user.user_metadata?.full_name ||
+        // OAuth プロバイダ由来の表示名にもサニタイズを適用 (HTML タグ・制御文字除去)。
+        const rawGoogleName = data.session.user.user_metadata?.full_name ||
                           data.session.user.user_metadata?.name ||
-                          data.session.user.email?.split('@')[0];
+                          data.session.user.email?.split('@')[0] ||
+                          '';
+        const googleName = sanitizePlainText(rawGoogleName).slice(0, 100);
 
         if (profileError && profileError.code === 'PGRST116') {
           // プロフィールが存在しない場合は新規作成

--- a/src/app/api/logs/errors/route.test.ts
+++ b/src/app/api/logs/errors/route.test.ts
@@ -54,7 +54,7 @@ describe('POST /api/logs/errors', () => {
     const res = await POST(req);
     expect(res.status).toBe(400);
     const data = await res.json();
-    expect(data.error).toBe('Invalid request body');
+    expect(data.error).toBeDefined();
   });
 
   it('returns 200 and received count on success', async () => {

--- a/src/app/api/logs/errors/route.ts
+++ b/src/app/api/logs/errors/route.ts
@@ -2,12 +2,38 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import type {
   ErrorCategory,
-  ErrorLogEntry,
   ErrorSeverity,
   PersistedErrorLog,
 } from '@/types/errorTracking';
-import { ErrorLogsBatchSchema } from '@/lib/validation/schemas';
+import { ErrorLogsBatchSchema, type ErrorLogsBatchInput } from '@/lib/validation/schemas';
 import { parseJsonBody } from '@/lib/validation/parse';
+
+/**
+ * zod スキーマ (`ErrorLogEntrySchema`) は `passthrough()` で柔軟に受けるため
+ * `ErrorLogEntry` 型と完全には一致しない。本ハンドラ内で必要な DB 行への
+ * 詰め替えに必要な最小フィールドだけを取り出す型として定義する。
+ */
+type ParsedLog = ErrorLogsBatchInput['logs'][number];
+
+function rowFromLog(log: ParsedLog, userId: string | null, fallbackSessionId: string | undefined) {
+  return {
+    id: log.id,
+    user_id: userId,
+    error_type: log.errorType as ErrorCategory,
+    message: log.message,
+    stack: log.stack ?? null,
+    status_code: log.statusCode ?? null,
+    severity: log.severity as ErrorSeverity,
+    page: log.context?.page ?? null,
+    action: log.context?.action ?? null,
+    url: log.context?.url ?? null,
+    user_agent: log.context?.userAgent ?? null,
+    session_id: log.context?.sessionId ?? fallbackSessionId ?? null,
+    metadata: (log as { metadata?: Record<string, unknown> }).metadata ?? null,
+    resolved: false,
+    created_at: safeToISOString(log.createdAt) ?? new Date().toISOString(),
+  };
+}
 
 type DbErrorLogRow = {
   id: string;
@@ -47,7 +73,7 @@ export async function POST(request: NextRequest) {
   const body = parsed.data;
 
   try {
-    const logs = body.logs.slice(0, MAX_BATCH_SIZE) as unknown as ErrorLogEntry[];
+    const logs = body.logs.slice(0, MAX_BATCH_SIZE);
 
     const supabase = await createClient();
     const {
@@ -57,23 +83,7 @@ export async function POST(request: NextRequest) {
     // Always use the server-verified userId; never trust client-supplied values.
     const userId = session?.user?.id ?? null;
 
-    const rows = logs.map((log) => ({
-      id: log.id,
-      user_id: userId,
-      error_type: log.errorType,
-      message: log.message,
-      stack: log.stack ?? null,
-      status_code: log.statusCode ?? null,
-      severity: log.severity,
-      page: log.context?.page ?? null,
-      action: log.context?.action ?? null,
-      url: log.context?.url ?? null,
-      user_agent: log.context?.userAgent ?? null,
-      session_id: log.context?.sessionId ?? body.sessionId ?? null,
-      metadata: log.metadata ?? null,
-      resolved: false,
-      created_at: safeToISOString(log.createdAt) ?? new Date().toISOString(),
-    }));
+    const rows = logs.map((log) => rowFromLog(log, userId, body.sessionId));
 
     const { error } = await supabase.from('error_logs').insert(rows);
 

--- a/src/app/api/logs/errors/route.ts
+++ b/src/app/api/logs/errors/route.ts
@@ -2,11 +2,12 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import type {
   ErrorCategory,
-  ErrorLogBatch,
   ErrorLogEntry,
   ErrorSeverity,
   PersistedErrorLog,
 } from '@/types/errorTracking';
+import { ErrorLogsBatchSchema } from '@/lib/validation/schemas';
+import { parseJsonBody } from '@/lib/validation/parse';
 
 type DbErrorLogRow = {
   id: string;
@@ -41,39 +42,12 @@ function safeToISOString(timestamp: number): string | null {
 }
 
 export async function POST(request: NextRequest) {
-  let body: ErrorLogBatch;
-  try {
-    body = (await request.json()) as ErrorLogBatch;
-  } catch {
-    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
-  }
+  const parsed = await parseJsonBody(request, ErrorLogsBatchSchema);
+  if (!parsed.ok) return parsed.response;
+  const body = parsed.data;
 
   try {
-    if (!body.logs || !Array.isArray(body.logs)) {
-      return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
-    }
-
-    const candidateLogs = body.logs.slice(0, MAX_BATCH_SIZE);
-
-    const isValidLog = (log: unknown): log is ErrorLogEntry => {
-      if (!log || typeof log !== 'object') return false;
-      const v = log as Partial<ErrorLogEntry>;
-      return (
-        typeof v.id === 'string' &&
-        typeof v.errorType === 'string' &&
-        typeof v.message === 'string' &&
-        typeof v.createdAt === 'number' &&
-        typeof v.severity === 'string' &&
-        !!v.context &&
-        typeof v.context === 'object'
-      );
-    };
-
-    if (!candidateLogs.every(isValidLog)) {
-      return NextResponse.json({ error: 'Invalid log entry' }, { status: 400 });
-    }
-
-    const logs: ErrorLogEntry[] = candidateLogs;
+    const logs = body.logs.slice(0, MAX_BATCH_SIZE) as unknown as ErrorLogEntry[];
 
     const supabase = await createClient();
     const {

--- a/src/app/api/preferences/route.ts
+++ b/src/app/api/preferences/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import type { NotificationPreferences } from '@/types/push';
-import { validateNotificationPreferences } from '@/lib/push/validation';
+import { PreferencesUpdateSchema } from '@/lib/validation/schemas';
+import { parseJsonBody } from '@/lib/validation/parse';
 
 const DEFAULT_PREFERENCES = {
   pwa_install_dismissed: false,
@@ -95,19 +96,9 @@ export async function PUT(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    let body: unknown;
-    try {
-      body = await request.json();
-    } catch {
-      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
-    }
-
-    if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
-    }
-
-    const { pwa_install_dismissed, timezone, notification_preferences } =
-      body as Record<string, unknown>;
+    const parsed = await parseJsonBody(request, PreferencesUpdateSchema);
+    if (!parsed.ok) return parsed.response;
+    const { pwa_install_dismissed, timezone, notification_preferences } = parsed.data;
 
     // 既存設定を取得（エラーを明示的に処理する）
     const { data: existing, error: existingError } = await supabase
@@ -126,44 +117,17 @@ export async function PUT(request: NextRequest) {
     const updates: Record<string, unknown> = {};
 
     if (pwa_install_dismissed !== undefined) {
-      if (typeof pwa_install_dismissed !== 'boolean') {
-        return NextResponse.json(
-          { error: 'pwa_install_dismissed は boolean である必要があります。' },
-          { status: 400 },
-        );
-      }
       updates.pwa_install_dismissed = pwa_install_dismissed;
     }
 
     if (timezone !== undefined) {
-      if (typeof timezone !== 'string' || timezone.trim() === '') {
-        return NextResponse.json(
-          { error: 'timezone は有効な文字列である必要があります。' },
-          { status: 400 },
-        );
-      }
-      updates.timezone = timezone.trim();
+      updates.timezone = timezone;
     }
 
     if (notification_preferences !== undefined) {
-      if (
-        typeof notification_preferences !== 'object' ||
-        notification_preferences === null ||
-        Array.isArray(notification_preferences)
-      ) {
-        return NextResponse.json(
-          { error: 'notification_preferences はオブジェクトである必要があります。' },
-          { status: 400 },
-        );
-      }
-      const validationError = validateNotificationPreferences(
-        notification_preferences as Record<string, unknown>,
-      );
-      if (validationError) {
-        return NextResponse.json({ error: validationError }, { status: 400 });
-      }
       const current =
-        existing?.notification_preferences ?? DEFAULT_PREFERENCES.notification_preferences;
+        (existing?.notification_preferences as NotificationPreferences | undefined) ??
+        DEFAULT_PREFERENCES.notification_preferences;
       updates.notification_preferences = { ...current, ...notification_preferences };
     }
 

--- a/src/app/api/preferences/route.ts
+++ b/src/app/api/preferences/route.ts
@@ -132,6 +132,10 @@ export async function PUT(request: NextRequest) {
     }
 
     if (existing) {
+      // 空の patch (`{}`) でも安全にパスするように、既存値をそのまま返す。
+      if (Object.keys(updates).length === 0) {
+        return NextResponse.json({ preferences: existing });
+      }
       const { data, error } = await supabase
         .from('user_preferences')
         .update(updates)

--- a/src/app/api/push/subscribe/route.test.ts
+++ b/src/app/api/push/subscribe/route.test.ts
@@ -13,18 +13,7 @@ vi.mock('@/lib/supabase/server', () => ({
   createClient: vi.fn().mockResolvedValue(mockSupabase),
 }));
 
-vi.mock('@/lib/push/encryption', () => ({
-  validatePushSubscriptionFields: vi.fn().mockReturnValue(null),
-}));
-
-vi.mock('@/utils/csrfToken', () => ({
-  CSRF_COOKIE_NAME: 'reflecthub-csrf',
-  CSRF_HEADER_NAME: 'x-csrf-token',
-  verifyCSRF: vi.fn().mockReturnValue({ ok: true }),
-}));
-
 import { POST } from './route';
-import { validatePushSubscriptionFields } from '@/lib/push/encryption';
 
 const USER = { id: 'user-1' };
 const VALID_BODY = {
@@ -40,18 +29,11 @@ const makeRequest = (body: unknown) =>
     headers: { 'Content-Type': 'application/json' },
   });
 
+// Note: CSRF 検証は middleware に移ったため本ファイルでは検証しない。
+// middleware の単体テスト (`middleware.test.ts`) で個別にカバーしている。
 describe('POST /api/push/subscribe', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(validatePushSubscriptionFields).mockReturnValue(null);
-  });
-
-  it('returns 403 when CSRF verification fails', async () => {
-    const csrf = await import('@/utils/csrfToken');
-    vi.mocked(csrf.verifyCSRF).mockReturnValueOnce({ ok: false, reason: 'mismatch' });
-    const res = await POST(makeRequest(VALID_BODY));
-    expect(res.status).toBe(403);
-    vi.mocked(csrf.verifyCSRF).mockReturnValue({ ok: true });
   });
 
   it('returns 401 when not authenticated', async () => {
@@ -68,11 +50,24 @@ describe('POST /api/push/subscribe', () => {
     expect(res.status).toBe(400);
   });
 
-  it('returns 400 when validation fails', async () => {
-    vi.mocked(validatePushSubscriptionFields).mockReturnValue('endpoint は有効な HTTPS URL である必要があります。');
+  it('returns 400 when endpoint is not https', async () => {
     mockSupabase.auth.getUser.mockResolvedValue({ data: { user: USER }, error: null });
 
-    const res = await POST(makeRequest(VALID_BODY));
+    const res = await POST(makeRequest({ ...VALID_BODY, endpoint: 'http://example.com/x' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when endpoint targets a private host', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: USER }, error: null });
+
+    const res = await POST(makeRequest({ ...VALID_BODY, endpoint: 'https://localhost/x' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when auth is not base64url', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: USER }, error: null });
+
+    const res = await POST(makeRequest({ ...VALID_BODY, auth: 'has spaces!' }));
     expect(res.status).toBe(400);
   });
 

--- a/src/app/api/push/subscribe/route.ts
+++ b/src/app/api/push/subscribe/route.ts
@@ -1,18 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-import { validatePushSubscriptionFields } from '@/lib/push/encryption';
-import { CSRF_COOKIE_NAME, CSRF_HEADER_NAME, verifyCSRF } from '@/utils/csrfToken';
+import { PushSubscribeSchema } from '@/lib/validation/schemas';
+import { parseJsonBody } from '@/lib/validation/parse';
 
 export async function POST(request: NextRequest) {
   try {
-    const csrf = verifyCSRF(
-      request.headers.get(CSRF_HEADER_NAME),
-      request.cookies.get(CSRF_COOKIE_NAME)?.value ?? null,
-    );
-    if (!csrf.ok) {
-      return NextResponse.json({ error: 'Invalid CSRF token' }, { status: 403 });
-    }
-
+    // CSRF は middleware で検証済み (defense-in-depth として個別ルートで再検証はしない)。
     const supabase = await createClient();
     const {
       data: { user },
@@ -23,40 +16,9 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    let body: unknown;
-    try {
-      body = await request.json();
-    } catch {
-      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
-    }
-
-    if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json(
-        { error: 'endpoint, p256dh, auth は必須です。' },
-        { status: 400 },
-      );
-    }
-
-    const { endpoint, p256dh, auth, user_agent, browser } = body as Record<string, unknown>;
-
-    if (
-      typeof endpoint !== 'string' ||
-      typeof p256dh !== 'string' ||
-      typeof auth !== 'string' ||
-      endpoint.trim() === '' ||
-      p256dh.trim() === '' ||
-      auth.trim() === ''
-    ) {
-      return NextResponse.json(
-        { error: 'endpoint, p256dh, auth は必須です。' },
-        { status: 400 },
-      );
-    }
-
-    const validationError = validatePushSubscriptionFields(endpoint, p256dh, auth);
-    if (validationError) {
-      return NextResponse.json({ error: validationError }, { status: 400 });
-    }
+    const parsed = await parseJsonBody(request, PushSubscribeSchema);
+    if (!parsed.ok) return parsed.response;
+    const { endpoint, p256dh, auth, user_agent, browser } = parsed.data;
 
     const { data, error } = await supabase
       .from('push_subscriptions')
@@ -66,8 +28,8 @@ export async function POST(request: NextRequest) {
           endpoint,
           p256dh,
           auth,
-          user_agent: typeof user_agent === 'string' ? user_agent : null,
-          browser: typeof browser === 'string' ? browser : null,
+          user_agent: user_agent ?? null,
+          browser: browser ?? null,
           is_active: true,
         },
         { onConflict: 'user_id,endpoint' },

--- a/src/app/api/push/unsubscribe/route.test.ts
+++ b/src/app/api/push/unsubscribe/route.test.ts
@@ -13,11 +13,7 @@ vi.mock('@/lib/supabase/server', () => ({
   createClient: vi.fn().mockResolvedValue(mockSupabase),
 }));
 
-vi.mock('@/utils/csrfToken', () => ({
-  CSRF_COOKIE_NAME: 'reflecthub-csrf',
-  CSRF_HEADER_NAME: 'x-csrf-token',
-  verifyCSRF: vi.fn().mockReturnValue({ ok: true }),
-}));
+// CSRF は middleware で検証する設計に変更したため、route 単体テストでは検証しない。
 
 import { POST } from './route';
 
@@ -47,6 +43,13 @@ describe('POST /api/push/unsubscribe', () => {
     mockSupabase.auth.getUser.mockResolvedValue({ data: { user: USER }, error: null });
 
     const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when endpoint targets a private host', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: USER }, error: null });
+
+    const res = await POST(makeRequest({ endpoint: 'https://localhost/abc' }));
     expect(res.status).toBe(400);
   });
 

--- a/src/app/api/push/unsubscribe/route.ts
+++ b/src/app/api/push/unsubscribe/route.ts
@@ -1,17 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-import { CSRF_COOKIE_NAME, CSRF_HEADER_NAME, verifyCSRF } from '@/utils/csrfToken';
+import { PushUnsubscribeSchema } from '@/lib/validation/schemas';
+import { parseJsonBody } from '@/lib/validation/parse';
 
 export async function POST(request: NextRequest) {
   try {
-    const csrf = verifyCSRF(
-      request.headers.get(CSRF_HEADER_NAME),
-      request.cookies.get(CSRF_COOKIE_NAME)?.value ?? null,
-    );
-    if (!csrf.ok) {
-      return NextResponse.json({ error: 'Invalid CSRF token' }, { status: 403 });
-    }
-
+    // CSRF は middleware で検証済み。
     const supabase = await createClient();
     const {
       data: { user },
@@ -22,25 +16,9 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    let body: unknown;
-    try {
-      body = await request.json();
-    } catch {
-      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
-    }
-
-    if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: 'endpoint は必須です。' }, { status: 400 });
-    }
-
-    const { endpoint } = body as { endpoint?: unknown };
-
-    if (typeof endpoint !== 'string' || endpoint.trim() === '') {
-      return NextResponse.json(
-        { error: 'endpoint は必須です。' },
-        { status: 400 },
-      );
-    }
+    const parsed = await parseJsonBody(request, PushUnsubscribeSchema);
+    if (!parsed.ok) return parsed.response;
+    const { endpoint } = parsed.data;
 
     const { error } = await supabase
       .from('push_subscriptions')

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabase/client';
+import { apiFetch } from '@/lib/api/apiClient';
 
 export default function AuthCallback() {
   const router = useRouter();
@@ -34,7 +35,7 @@ export default function AuthCallback() {
           // サーバー側のセッションを設定
           if (sessionData.session) {
             try {
-              const response = await fetch('/api/auth/session', {
+              const response = await apiFetch('/api/auth/session', {
                 method: 'POST',
                 headers: {
                   'Content-Type': 'application/json',

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -7,6 +7,7 @@ import { ProfileCard } from '@/components/profile/ProfileCard';
 import Header from '@/components/layout/Header';
 import DashboardLoading from '../dashboard/loading';
 import { FadeIn } from '@/components/animations/FadeIn';
+import { apiFetch } from '@/lib/api/apiClient';
 
 export default function ProfilePage() {
   const { user, signOut, isLoading, error } = useAuth();
@@ -32,7 +33,7 @@ export default function ProfilePage() {
     setUpdateError(null);
 
     try {
-      const response = await fetch(`/api/auth/profile/${user.id}`, {
+      const response = await apiFetch(`/api/auth/profile/${user.id}`, {
         method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',

--- a/src/hooks/useSessionManager.ts
+++ b/src/hooks/useSessionManager.ts
@@ -4,6 +4,7 @@ import { useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { supabase } from "@/lib/supabase/client";
 import { useAuthStore } from "@/stores/authStore";
+import { apiFetch } from "@/lib/api/apiClient";
 
 export function useSessionManager() {
   const router = useRouter();
@@ -30,7 +31,7 @@ export function useSessionManager() {
           // セッションが存在する場合、サーバー側にもセッションを確立
           if (session) {
             try {
-              const response = await fetch('/api/auth/session', {
+              const response = await apiFetch('/api/auth/session', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 credentials: 'include',

--- a/src/lib/api/apiClient.test.ts
+++ b/src/lib/api/apiClient.test.ts
@@ -7,11 +7,12 @@ describe('apiFetch', () => {
   beforeEach(() => {
     _resetCSRFCacheForTest();
     fetchMock = vi.fn();
-    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+    vi.stubGlobal('fetch', fetchMock);
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   function csrfResponse(token: string) {

--- a/src/lib/api/apiClient.test.ts
+++ b/src/lib/api/apiClient.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { apiFetch, _resetCSRFCacheForTest } from './apiClient';
+
+describe('apiFetch', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    _resetCSRFCacheForTest();
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function csrfResponse(token: string) {
+    return new Response(JSON.stringify({ token }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  it('does not attach CSRF header for GET', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('ok', { status: 200 }));
+    await apiFetch('/api/foo', { method: 'GET' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    const headers = new Headers(init.headers ?? undefined);
+    expect(headers.get('X-CSRF-Token')).toBeNull();
+  });
+
+  it('attaches CSRF header on POST and fetches token first time', async () => {
+    fetchMock
+      .mockResolvedValueOnce(csrfResponse('abc.def'))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+    await apiFetch('/api/foo', { method: 'POST', body: '{}' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/csrf');
+    const postInit = fetchMock.mock.calls[1][1] as RequestInit;
+    const headers = new Headers(postInit.headers ?? undefined);
+    expect(headers.get('X-CSRF-Token')).toBe('abc.def');
+  });
+
+  it('reuses cached token on subsequent calls', async () => {
+    fetchMock
+      .mockResolvedValueOnce(csrfResponse('cached.tok'))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+    await apiFetch('/api/a', { method: 'POST' });
+    await apiFetch('/api/b', { method: 'POST' });
+
+    // 1 csrf fetch + 2 actual calls
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/csrf');
+  });
+
+  it('refreshes token on 403 and retries once', async () => {
+    fetchMock
+      .mockResolvedValueOnce(csrfResponse('stale.tok'))
+      .mockResolvedValueOnce(new Response('forbidden', { status: 403 }))
+      .mockResolvedValueOnce(csrfResponse('fresh.tok'))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+    const res = await apiFetch('/api/foo', { method: 'POST' });
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    const retryInit = fetchMock.mock.calls[3][1] as RequestInit;
+    const headers = new Headers(retryInit.headers ?? undefined);
+    expect(headers.get('X-CSRF-Token')).toBe('fresh.tok');
+  });
+});

--- a/src/lib/api/apiClient.ts
+++ b/src/lib/api/apiClient.ts
@@ -1,0 +1,78 @@
+/**
+ * クライアント (ブラウザ) から自前 API を呼ぶための薄いラッパー。
+ *
+ * - mutation メソッド (POST/PUT/PATCH/DELETE) のときは `/api/csrf` から取得した
+ *   トークンを `X-CSRF-Token` ヘッダに自動付与する。
+ * - 取得したトークンはモジュールスコープにキャッシュし、403 が返ったときだけ
+ *   再取得する (Cookie とトークンが期限切れだった場合のリトライ)。
+ *
+ * React のフック (`useCSRFToken`) はコンポーネント内で使えるが、Zustand store や
+ * シングルトンクラスからは呼べないため本ヘルパーを使う。
+ */
+
+const CSRF_ENDPOINT = '/api/csrf';
+const CSRF_HEADER = 'X-CSRF-Token';
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+let cachedToken: string | null = null;
+let inflight: Promise<string | null> | null = null;
+
+async function fetchToken(): Promise<string | null> {
+  if (inflight) return inflight;
+  inflight = (async () => {
+    try {
+      const res = await fetch(CSRF_ENDPOINT, {
+        method: 'GET',
+        credentials: 'same-origin',
+        cache: 'no-store',
+      });
+      if (!res.ok) return null;
+      const data = (await res.json().catch(() => ({}))) as { token?: string };
+      cachedToken = data.token ?? null;
+      return cachedToken;
+    } finally {
+      inflight = null;
+    }
+  })();
+  return inflight;
+}
+
+async function getToken(forceRefresh = false): Promise<string | null> {
+  if (!forceRefresh && cachedToken) return cachedToken;
+  return fetchToken();
+}
+
+function isMutating(method: string | undefined): boolean {
+  return MUTATING_METHODS.has((method ?? 'GET').toUpperCase());
+}
+
+async function applyCSRFHeader(init: RequestInit, forceRefresh = false): Promise<RequestInit> {
+  if (!isMutating(init.method)) return init;
+  const token = await getToken(forceRefresh);
+  if (!token) return init;
+  const headers = new Headers(init.headers ?? undefined);
+  headers.set(CSRF_HEADER, token);
+  return { ...init, headers };
+}
+
+/**
+ * 自動的に CSRF トークンを付与する fetch。
+ * 同一オリジンの自前 API を呼ぶ用途を想定。
+ */
+export async function apiFetch(input: RequestInfo | URL, init: RequestInit = {}): Promise<Response> {
+  const initWithCsrf = await applyCSRFHeader({ credentials: 'same-origin', ...init });
+  const res = await fetch(input, initWithCsrf);
+
+  // 403 (CSRF 失敗の可能性) の場合は 1 度だけトークンを再取得してリトライする。
+  if (res.status === 403 && isMutating(init.method)) {
+    const retryInit = await applyCSRFHeader({ credentials: 'same-origin', ...init }, true);
+    return fetch(input, retryInit);
+  }
+  return res;
+}
+
+/** テスト用: モジュール内のキャッシュを破棄する。 */
+export function _resetCSRFCacheForTest(): void {
+  cachedToken = null;
+  inflight = null;
+}

--- a/src/lib/errorTracking/client.ts
+++ b/src/lib/errorTracking/client.ts
@@ -5,6 +5,7 @@ import type {
   ErrorSeverity,
   ErrorTrackingContext,
 } from '@/types/errorTracking';
+import { apiFetch } from '@/lib/api/apiClient';
 
 const BATCH_SIZE = 10;
 const BATCH_INTERVAL_MS = 30_000;
@@ -138,7 +139,7 @@ class ErrorTrackingClient {
         sentAt: Date.now(),
       };
 
-      const res = await fetch('/api/logs/errors', {
+      const res = await apiFetch('/api/logs/errors', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),

--- a/src/lib/validation/parse.test.ts
+++ b/src/lib/validation/parse.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { parseJsonBody } from './parse';
+import type { NextRequest } from 'next/server';
+
+function makeRequest(body: string | object): NextRequest {
+  const text = typeof body === 'string' ? body : JSON.stringify(body);
+  return {
+    json: async () => {
+      try {
+        return JSON.parse(text);
+      } catch (e) {
+        throw e;
+      }
+    },
+  } as unknown as NextRequest;
+}
+
+const schema = z.object({ name: z.string().min(1) }).strict();
+
+describe('parseJsonBody', () => {
+  it('returns ok=true with parsed data on valid input', async () => {
+    const req = makeRequest({ name: 'taro' });
+    const result = await parseJsonBody(req, schema);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data).toEqual({ name: 'taro' });
+  });
+
+  it('returns 400 on malformed JSON', async () => {
+    const req = makeRequest('not-json');
+    const result = await parseJsonBody(req, schema);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(400);
+      const body = await result.response.json();
+      expect(body.error).toBe('Invalid JSON body');
+    }
+  });
+
+  it('returns 400 with issues on schema mismatch', async () => {
+    const req = makeRequest({ name: '' });
+    const result = await parseJsonBody(req, schema);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(400);
+      const body = await result.response.json();
+      expect(Array.isArray(body.issues)).toBe(true);
+      expect(body.issues.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('rejects extra keys when schema is strict', async () => {
+    const req = makeRequest({ name: 'taro', extra: 1 });
+    const result = await parseJsonBody(req, schema);
+    expect(result.ok).toBe(false);
+  });
+});

--- a/src/lib/validation/parse.ts
+++ b/src/lib/validation/parse.ts
@@ -1,0 +1,47 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import type { ZodType } from 'zod';
+
+/**
+ * リクエスト JSON ボディを zod スキーマで検証する共通ヘルパー。
+ *
+ * - JSON パース失敗時は 400 `Invalid JSON body`
+ * - スキーマ不一致時は 400 とフィールドごとのエラーを返す
+ *
+ * 成功時は `{ ok: true, data }`、失敗時は `{ ok: false, response }` を返し、
+ * 呼び出し側ではそのまま `return response` できる。
+ */
+export type ParseResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; response: NextResponse };
+
+export async function parseJsonBody<T>(
+  request: NextRequest,
+  schema: ZodType<T>,
+): Promise<ParseResult<T>> {
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }),
+    };
+  }
+
+  const result = schema.safeParse(raw);
+  if (!result.success) {
+    const issues = result.error.issues.map((i) => ({
+      path: i.path.join('.'),
+      message: i.message,
+    }));
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: issues[0]?.message ?? 'Validation failed', issues },
+        { status: 400 },
+      ),
+    };
+  }
+
+  return { ok: true, data: result.data };
+}

--- a/src/lib/validation/schemas.test.ts
+++ b/src/lib/validation/schemas.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PreferencesUpdateSchema,
+  PushSubscribeSchema,
+  PushUnsubscribeSchema,
+  ProfileUpdateSchema,
+  SessionCreateSchema,
+  ErrorLogsBatchSchema,
+} from './schemas';
+
+describe('PreferencesUpdateSchema', () => {
+  it('accepts an empty patch', () => {
+    expect(PreferencesUpdateSchema.safeParse({}).success).toBe(true);
+  });
+
+  it('accepts a valid full payload', () => {
+    const result = PreferencesUpdateSchema.safeParse({
+      pwa_install_dismissed: true,
+      timezone: 'Asia/Tokyo',
+      notification_preferences: {
+        daily_reminder: true,
+        reminder_time: '20:30',
+        weekly_summary: false,
+        achievement_alerts: true,
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects unknown top-level keys', () => {
+    expect(
+      PreferencesUpdateSchema.safeParse({ unknown_field: true }).success,
+    ).toBe(false);
+  });
+
+  it('rejects unknown notification_preferences keys', () => {
+    expect(
+      PreferencesUpdateSchema.safeParse({
+        notification_preferences: { evil_field: true },
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects invalid reminder_time format', () => {
+    expect(
+      PreferencesUpdateSchema.safeParse({
+        notification_preferences: { reminder_time: '25:00' },
+      }).success,
+    ).toBe(false);
+    expect(
+      PreferencesUpdateSchema.safeParse({
+        notification_preferences: { reminder_time: '9:00' },
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects non-boolean booleans', () => {
+    expect(
+      PreferencesUpdateSchema.safeParse({ pwa_install_dismissed: 'true' }).success,
+    ).toBe(false);
+  });
+
+  it('trims timezone string', () => {
+    const result = PreferencesUpdateSchema.parse({ timezone: '  Asia/Tokyo  ' });
+    expect(result.timezone).toBe('Asia/Tokyo');
+  });
+});
+
+describe('PushSubscribeSchema', () => {
+  const valid = {
+    endpoint: 'https://fcm.googleapis.com/wp/abc',
+    p256dh: 'ABCDEFGabc-_1234',
+    auth: 'XYZ_-abc12==',
+  };
+
+  it('accepts a valid payload', () => {
+    expect(PushSubscribeSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it('rejects http endpoint', () => {
+    expect(
+      PushSubscribeSchema.safeParse({ ...valid, endpoint: 'http://example.com/x' }).success,
+    ).toBe(false);
+  });
+
+  it('rejects internal endpoint', () => {
+    expect(
+      PushSubscribeSchema.safeParse({ ...valid, endpoint: 'https://localhost/x' }).success,
+    ).toBe(false);
+  });
+
+  it('rejects non-base64url auth', () => {
+    expect(
+      PushSubscribeSchema.safeParse({ ...valid, auth: 'has spaces!' }).success,
+    ).toBe(false);
+  });
+
+  it('rejects extra keys', () => {
+    expect(
+      PushSubscribeSchema.safeParse({ ...valid, evil: true }).success,
+    ).toBe(false);
+  });
+});
+
+describe('PushUnsubscribeSchema', () => {
+  it('accepts a valid endpoint', () => {
+    expect(
+      PushUnsubscribeSchema.safeParse({ endpoint: 'https://fcm.googleapis.com/wp/abc' }).success,
+    ).toBe(true);
+  });
+
+  it('rejects empty endpoint', () => {
+    expect(PushUnsubscribeSchema.safeParse({ endpoint: '' }).success).toBe(false);
+  });
+});
+
+describe('ProfileUpdateSchema', () => {
+  it('accepts a valid name', () => {
+    expect(ProfileUpdateSchema.safeParse({ name: '太郎' }).success).toBe(true);
+  });
+
+  it('trims and validates length', () => {
+    const result = ProfileUpdateSchema.parse({ name: '   太郎   ' });
+    expect(result.name).toBe('太郎');
+  });
+
+  it('rejects empty name after trim', () => {
+    expect(ProfileUpdateSchema.safeParse({ name: '   ' }).success).toBe(false);
+  });
+
+  it('rejects names over 100 chars', () => {
+    expect(
+      ProfileUpdateSchema.safeParse({ name: 'a'.repeat(101) }).success,
+    ).toBe(false);
+  });
+});
+
+describe('SessionCreateSchema', () => {
+  it('accepts valid tokens', () => {
+    expect(
+      SessionCreateSchema.safeParse({
+        access_token: 'aaa',
+        refresh_token: 'bbb',
+      }).success,
+    ).toBe(true);
+  });
+
+  it('rejects missing tokens', () => {
+    expect(
+      SessionCreateSchema.safeParse({ access_token: 'aaa' }).success,
+    ).toBe(false);
+    expect(
+      SessionCreateSchema.safeParse({ access_token: '', refresh_token: 'b' }).success,
+    ).toBe(false);
+  });
+});
+
+describe('ErrorLogsBatchSchema', () => {
+  const validLog = {
+    id: 'l_1',
+    errorType: 'network',
+    message: 'failed',
+    severity: 'error',
+    createdAt: Date.now(),
+    context: { page: '/dashboard' },
+  };
+
+  it('accepts a valid batch', () => {
+    expect(
+      ErrorLogsBatchSchema.safeParse({ logs: [validLog], sessionId: 's' }).success,
+    ).toBe(true);
+  });
+
+  it('rejects empty logs array', () => {
+    expect(ErrorLogsBatchSchema.safeParse({ logs: [] }).success).toBe(false);
+  });
+
+  it('rejects too-large batches', () => {
+    const big = Array.from({ length: 51 }, () => validLog);
+    expect(ErrorLogsBatchSchema.safeParse({ logs: big }).success).toBe(false);
+  });
+
+  it('rejects entries missing required fields', () => {
+    expect(
+      ErrorLogsBatchSchema.safeParse({
+        logs: [{ ...validLog, id: undefined }],
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/src/lib/validation/schemas.ts
+++ b/src/lib/validation/schemas.ts
@@ -1,0 +1,153 @@
+import { z } from 'zod';
+import { isValidPushEndpoint } from '@/utils/urlValidation';
+
+/**
+ * 共通: 文字列を trim した上で長さチェックするユーティリティ。
+ */
+const trimmedString = (min: number, max: number) =>
+  z
+    .string()
+    .transform((v) => v.trim())
+    .refine((v) => v.length >= min && v.length <= max, {
+      message: `${min}〜${max} 文字で入力してください。`,
+    });
+
+const HHMM_PATTERN = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
+
+const BASE64URL_PATTERN = /^[A-Za-z0-9\-_]+=*$/;
+
+// ───────────────────────────────────────────────────────────────────
+// /api/preferences PUT
+// ───────────────────────────────────────────────────────────────────
+
+export const NotificationPreferencesPatchSchema = z
+  .object({
+    daily_reminder: z.boolean().optional(),
+    weekly_summary: z.boolean().optional(),
+    achievement_alerts: z.boolean().optional(),
+    reminder_time: z
+      .string()
+      .regex(HHMM_PATTERN, {
+        error: 'reminder_time は HH:MM 形式 (00:00〜23:59) である必要があります。',
+      })
+      .optional(),
+  })
+  .strict();
+
+export const PreferencesUpdateSchema = z
+  .object({
+    pwa_install_dismissed: z.boolean().optional(),
+    timezone: trimmedString(1, 100).optional(),
+    notification_preferences: NotificationPreferencesPatchSchema.optional(),
+  })
+  .strict();
+
+export type PreferencesUpdateInput = z.infer<typeof PreferencesUpdateSchema>;
+
+// ───────────────────────────────────────────────────────────────────
+// /api/push/subscribe POST
+// ───────────────────────────────────────────────────────────────────
+
+export const PushSubscribeSchema = z
+  .object({
+    endpoint: z
+      .string()
+      .min(1)
+      .refine(isValidPushEndpoint, {
+        message: 'endpoint は公開到達可能な HTTPS URL である必要があります。',
+      }),
+    p256dh: z
+      .string()
+      .min(1)
+      .regex(BASE64URL_PATTERN, { error: 'p256dh は Base64url 文字列である必要があります。' }),
+    auth: z
+      .string()
+      .min(1)
+      .regex(BASE64URL_PATTERN, { error: 'auth は Base64url 文字列である必要があります。' }),
+    user_agent: z.string().max(500).optional(),
+    browser: z.string().max(100).optional(),
+  })
+  .strict();
+
+export type PushSubscribeInput = z.infer<typeof PushSubscribeSchema>;
+
+// ───────────────────────────────────────────────────────────────────
+// /api/push/unsubscribe POST
+// ───────────────────────────────────────────────────────────────────
+
+export const PushUnsubscribeSchema = z
+  .object({
+    endpoint: z
+      .string()
+      .min(1)
+      .refine(isValidPushEndpoint, {
+        message: 'endpoint は公開到達可能な HTTPS URL である必要があります。',
+      }),
+  })
+  .strict();
+
+export type PushUnsubscribeInput = z.infer<typeof PushUnsubscribeSchema>;
+
+// ───────────────────────────────────────────────────────────────────
+// /api/auth/profile/[userId] PATCH
+// ───────────────────────────────────────────────────────────────────
+
+export const ProfileUpdateSchema = z
+  .object({
+    name: trimmedString(1, 100),
+  })
+  .strict();
+
+export type ProfileUpdateInput = z.infer<typeof ProfileUpdateSchema>;
+
+// ───────────────────────────────────────────────────────────────────
+// /api/auth/session POST
+// ───────────────────────────────────────────────────────────────────
+
+export const SessionCreateSchema = z
+  .object({
+    access_token: z.string().min(1),
+    refresh_token: z.string().min(1),
+  })
+  .strict();
+
+export type SessionCreateInput = z.infer<typeof SessionCreateSchema>;
+
+// ───────────────────────────────────────────────────────────────────
+// /api/logs/errors POST
+// ───────────────────────────────────────────────────────────────────
+
+const ErrorLogContextSchema = z
+  .object({
+    page: z.string().max(2048).optional(),
+    action: z.string().max(200).optional(),
+    url: z.string().max(2048).optional(),
+    userAgent: z.string().max(500).optional(),
+    sessionId: z.string().max(100).optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
+  })
+  .passthrough();
+
+const ErrorLogEntrySchema = z
+  .object({
+    id: z.string().min(1).max(100),
+    errorType: z.string().min(1).max(100),
+    message: z.string().max(5000),
+    stack: z.string().max(20000).optional(),
+    statusCode: z.number().int().optional(),
+    severity: z.string().min(1).max(50),
+    createdAt: z.number(),
+    context: ErrorLogContextSchema,
+  })
+  .passthrough();
+
+export const ErrorLogsBatchSchema = z
+  .object({
+    logs: z.array(ErrorLogEntrySchema).min(1).max(50),
+    sessionId: z.string().max(100).optional(),
+    batchId: z.string().max(100).optional(),
+    sentAt: z.number().optional(),
+  })
+  .strict();
+
+export type ErrorLogsBatchInput = z.infer<typeof ErrorLogsBatchSchema>;

--- a/src/services/errorLoggingService.ts
+++ b/src/services/errorLoggingService.ts
@@ -1,3 +1,5 @@
+import { apiFetch } from '@/lib/api/apiClient';
+
 export interface ErrorLog {
   id: string;
   timestamp: number;
@@ -72,7 +74,7 @@ class ErrorLoggingService {
     this.queue = [];
 
     try {
-      await fetch('/api/logs/errors', {
+      await apiFetch('/api/logs/errors', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ logs: logsToSend, sessionId: this.sessionId }),

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { supabase } from "@/lib/supabase/client";
+import { apiFetch } from "@/lib/api/apiClient";
 import type {
   User,
   AuthState,
@@ -58,7 +59,7 @@ export const useAuthStore = create<AuthStore>()(
         try {
           // サーバー側のセッションもクリア
           try {
-            await fetch('/api/auth/logout', {
+            await apiFetch('/api/auth/logout', {
               method: 'POST',
               credentials: 'include',
             });

--- a/src/utils/csrfToken.ts
+++ b/src/utils/csrfToken.ts
@@ -1,14 +1,20 @@
 import { createHmac, randomBytes, timingSafeEqual } from 'crypto';
 
 /**
- * CSRF トークン生成・検証
+ * CSRF トークン生成・検証 (Node ランタイム用)
  *
  * Double Submit Cookie 戦略 + HMAC 署名を採用。
  * トークンは `<random>.<hmac>` の形で発行され、Cookie とリクエストヘッダの一致を検証する。
+ *
+ * 定数 / 型は Edge ランタイムからも参照するため `csrfTokenEdge.ts` で定義し、
+ * 本モジュールでは re-export している。
  */
 
-export const CSRF_COOKIE_NAME = 'reflecthub-csrf';
-export const CSRF_HEADER_NAME = 'x-csrf-token';
+export {
+  CSRF_COOKIE_NAME,
+  CSRF_HEADER_NAME,
+  type CSRFValidationResult,
+} from './csrfTokenEdge';
 
 const TOKEN_BYTE_LENGTH = 32;
 
@@ -58,10 +64,7 @@ export function tokensMatch(headerToken: string | null, cookieToken: string | nu
   return timingSafeEqual(a, b);
 }
 
-export interface CSRFValidationResult {
-  ok: boolean;
-  reason?: 'missing_header' | 'missing_cookie' | 'mismatch' | 'invalid_signature';
-}
+import type { CSRFValidationResult } from './csrfTokenEdge';
 
 export function verifyCSRF(
   headerToken: string | null,

--- a/src/utils/csrfTokenEdge.test.ts
+++ b/src/utils/csrfTokenEdge.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { generateCSRFToken } from './csrfToken';
+import { verifyCSRFAsync } from './csrfTokenEdge';
+
+describe('csrfTokenEdge', () => {
+  const ORIGINAL_SECRET = process.env.CSRF_SECRET;
+
+  beforeAll(() => {
+    process.env.CSRF_SECRET = 'test-secret-for-edge-1234567890abc';
+  });
+
+  afterAll(() => {
+    if (ORIGINAL_SECRET === undefined) {
+      delete process.env.CSRF_SECRET;
+    } else {
+      process.env.CSRF_SECRET = ORIGINAL_SECRET;
+    }
+  });
+
+  it('accepts a freshly generated token submitted in both header and cookie', async () => {
+    const token = generateCSRFToken();
+    expect(await verifyCSRFAsync(token, token)).toEqual({ ok: true });
+  });
+
+  it('reports missing_header when header is null', async () => {
+    expect(await verifyCSRFAsync(null, 'x')).toEqual({ ok: false, reason: 'missing_header' });
+  });
+
+  it('reports missing_cookie when cookie is null', async () => {
+    expect(await verifyCSRFAsync('x', null)).toEqual({ ok: false, reason: 'missing_cookie' });
+  });
+
+  it('reports mismatch when header and cookie differ', async () => {
+    const a = generateCSRFToken();
+    const b = generateCSRFToken();
+    expect(await verifyCSRFAsync(a, b)).toEqual({ ok: false, reason: 'mismatch' });
+  });
+
+  it('reports invalid_signature when signature is tampered', async () => {
+    const token = generateCSRFToken();
+    const [random] = token.split('.');
+    const tampered = `${random}.deadbeef`;
+    expect(await verifyCSRFAsync(tampered, tampered)).toEqual({
+      ok: false,
+      reason: 'invalid_signature',
+    });
+  });
+
+  it('reports invalid_signature on malformed token', async () => {
+    expect(await verifyCSRFAsync('no-dot', 'no-dot')).toEqual({
+      ok: false,
+      reason: 'invalid_signature',
+    });
+  });
+});

--- a/src/utils/csrfTokenEdge.ts
+++ b/src/utils/csrfTokenEdge.ts
@@ -7,10 +7,18 @@
  * トークン形式・署名アルゴリズム (HMAC-SHA256) は `csrfToken.ts` と互換。
  *
  * トークン生成は引き続き `csrfToken.ts` の `generateCSRFToken` を使う想定で、
- * ここでは検証 (verify) のみを提供する。
+ * ここでは検証 (verify) と Edge から参照される定数のみを提供する。
  */
 
-import type { CSRFValidationResult } from './csrfToken';
+// Cookie / ヘッダ名の定数は Edge runtime からも参照されるため本ファイルに置く。
+// Node 側 (`csrfToken.ts`) も Edge 経由で同じ値を再エクスポートする。
+export const CSRF_COOKIE_NAME = 'reflecthub-csrf';
+export const CSRF_HEADER_NAME = 'x-csrf-token';
+
+export interface CSRFValidationResult {
+  ok: boolean;
+  reason?: 'missing_header' | 'missing_cookie' | 'mismatch' | 'invalid_signature';
+}
 
 const encoder = new TextEncoder();
 
@@ -71,11 +79,7 @@ async function verifySignature(random: string, signatureHex: string): Promise<bo
   const sigBytes = hexToBytes(signatureHex);
   if (!sigBytes) return false;
   const key = await getHmacKey(secret);
-  // crypto.subtle.verify は BufferSource を要求する。Uint8Array.buffer の型差を避けるため
-  // 一度新しい ArrayBuffer に転写する。
-  const sigBuffer = sigBytes.slice().buffer;
-  const dataBuffer = encoder.encode(random).slice().buffer;
-  return crypto.subtle.verify('HMAC', key, sigBuffer, dataBuffer);
+  return crypto.subtle.verify('HMAC', key, sigBytes as BufferSource, encoder.encode(random));
 }
 
 /**

--- a/src/utils/csrfTokenEdge.ts
+++ b/src/utils/csrfTokenEdge.ts
@@ -1,0 +1,104 @@
+/**
+ * Edge runtime 互換の CSRF 検証ユーティリティ。
+ *
+ * `csrfToken.ts` は Node の `crypto` モジュール (`createHmac` 等) に依存して
+ * いるため Next.js の Edge runtime で動く middleware から直接呼べない。
+ * 本ファイルは Web Crypto API (`crypto.subtle`) のみで実装した非同期版で、
+ * トークン形式・署名アルゴリズム (HMAC-SHA256) は `csrfToken.ts` と互換。
+ *
+ * トークン生成は引き続き `csrfToken.ts` の `generateCSRFToken` を使う想定で、
+ * ここでは検証 (verify) のみを提供する。
+ */
+
+import type { CSRFValidationResult } from './csrfToken';
+
+const encoder = new TextEncoder();
+
+function getSecret(): string {
+  const secret = process.env.CSRF_SECRET;
+  if (!secret || secret.length < 16) {
+    throw new Error('CSRF_SECRET 環境変数が設定されていないか、短すぎます。');
+  }
+  return secret;
+}
+
+function hexToBytes(hex: string): Uint8Array | null {
+  if (hex.length % 2 !== 0) return null;
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    const byte = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+    if (Number.isNaN(byte)) return null;
+    bytes[i] = byte;
+  }
+  return bytes;
+}
+
+function timingSafeEqualBytes(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i];
+  return diff === 0;
+}
+
+function timingSafeEqualStrings(a: string, b: string): boolean {
+  // 長さが違うと早期リターンせざるを得ないが、CSRF トークンは固定長なので問題ない。
+  if (a.length !== b.length) return false;
+  return timingSafeEqualBytes(encoder.encode(a), encoder.encode(b));
+}
+
+let cachedKey: { secret: string; key: CryptoKey } | null = null;
+
+async function getHmacKey(secret: string): Promise<CryptoKey> {
+  if (cachedKey && cachedKey.secret === secret) return cachedKey.key;
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['verify'],
+  );
+  cachedKey = { secret, key };
+  return key;
+}
+
+async function verifySignature(random: string, signatureHex: string): Promise<boolean> {
+  let secret: string;
+  try {
+    secret = getSecret();
+  } catch {
+    return false;
+  }
+  const sigBytes = hexToBytes(signatureHex);
+  if (!sigBytes) return false;
+  const key = await getHmacKey(secret);
+  // crypto.subtle.verify は BufferSource を要求する。Uint8Array.buffer の型差を避けるため
+  // 一度新しい ArrayBuffer に転写する。
+  const sigBuffer = sigBytes.slice().buffer;
+  const dataBuffer = encoder.encode(random).slice().buffer;
+  return crypto.subtle.verify('HMAC', key, sigBuffer, dataBuffer);
+}
+
+/**
+ * Edge runtime / Web Crypto を使った非同期 CSRF 検証。
+ * 結果の型 (`CSRFValidationResult`) は `csrfToken.ts` の同期版と共通。
+ */
+export async function verifyCSRFAsync(
+  headerToken: string | null,
+  cookieToken: string | null,
+): Promise<CSRFValidationResult> {
+  if (!headerToken) return { ok: false, reason: 'missing_header' };
+  if (!cookieToken) return { ok: false, reason: 'missing_cookie' };
+  if (!timingSafeEqualStrings(headerToken, cookieToken)) {
+    return { ok: false, reason: 'mismatch' };
+  }
+
+  const dot = headerToken.indexOf('.');
+  if (dot <= 0 || dot === headerToken.length - 1) {
+    return { ok: false, reason: 'invalid_signature' };
+  }
+  const random = headerToken.slice(0, dot);
+  const signature = headerToken.slice(dot + 1);
+
+  const ok = await verifySignature(random, signature);
+  return ok ? { ok: true } : { ok: false, reason: 'invalid_signature' };
+}

--- a/src/utils/sanitize.test.ts
+++ b/src/utils/sanitize.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizePlainText } from './sanitize';
+
+describe('sanitizePlainText', () => {
+  it('strips HTML tags', () => {
+    expect(sanitizePlainText('<script>alert(1)</script>hello')).toBe('alert(1)hello');
+    expect(sanitizePlainText('<b>bold</b>')).toBe('bold');
+    expect(sanitizePlainText('<img src=x onerror=alert(1)>nope')).toBe('nope');
+  });
+
+  it('strips HTML comments', () => {
+    expect(sanitizePlainText('hello<!-- secret -->world')).toBe('helloworld');
+  });
+
+  it('strips control characters but keeps newlines/tabs', () => {
+    expect(sanitizePlainText('abc')).toBe('abc');
+    expect(sanitizePlainText('line1\nline2')).toBe('line1\nline2');
+    expect(sanitizePlainText('a\tb')).toBe('a\tb');
+  });
+
+  it('trims whitespace', () => {
+    expect(sanitizePlainText('   hello   ')).toBe('hello');
+  });
+
+  it('returns empty string for non-strings', () => {
+    // @ts-expect-error - testing runtime behavior
+    expect(sanitizePlainText(null)).toBe('');
+    // @ts-expect-error - testing runtime behavior
+    expect(sanitizePlainText(undefined)).toBe('');
+    // @ts-expect-error - testing runtime behavior
+    expect(sanitizePlainText(123)).toBe('');
+  });
+
+  it('preserves plain text unchanged', () => {
+    expect(sanitizePlainText('普通の名前 太郎')).toBe('普通の名前 太郎');
+  });
+});

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,0 +1,21 @@
+/**
+ * サーバー側でユーザー入力をサニタイズするユーティリティ。
+ *
+ * クライアント側 (`src/utils/validation.ts`) では DOMPurify を通しているが、
+ * DOMPurify は実行に DOM (window) が必要なため Node ランタイムの API ルートでは
+ * 使いづらい。プレーンテキストとして保存したいフィールドに関しては、
+ * 「タグ・コメント・制御文字を除去する」だけで十分なので軽量な実装を提供する。
+ *
+ * Markdown 等の安全なリッチテキストを通したいフィールドは別途専用の
+ * サニタイザを用意すること。本関数は「プレーンテキストとして安全」を保証する。
+ */
+
+// HTML タグ (開閉) と HTML コメントをまとめて除去
+const HTML_TAG_OR_COMMENT = /<!--[\s\S]*?-->|<\/?[a-zA-Z][^<>]*>/g;
+// 制御文字 (\n \r \t は許容)
+const CONTROL_CHARS = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g;
+
+export function sanitizePlainText(value: string): string {
+  if (typeof value !== 'string') return '';
+  return value.replace(HTML_TAG_OR_COMMENT, '').replace(CONTROL_CHARS, '').trim();
+}

--- a/src/utils/urlValidation.test.ts
+++ b/src/utils/urlValidation.test.ts
@@ -45,6 +45,11 @@ describe('isValidUrl', () => {
       'http://[::1]/',
       'http://[fe80::1]/',
       'http://[fc00::1]/',
+      // IPv4-mapped IPv6 — URL は `::ffff:7f00:1` 等に正規化する
+      'http://[::ffff:127.0.0.1]/',
+      'http://[::ffff:169.254.169.254]/',
+      'http://[::ffff:10.0.0.1]/',
+      'http://[0:0:0:0:0:ffff:127.0.0.1]/',
     ])('rejects %s', (url) => {
       expect(isValidUrl(url)).toBe(false);
     });

--- a/src/utils/urlValidation.test.ts
+++ b/src/utils/urlValidation.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { isValidUrl, isValidPushEndpoint } from './urlValidation';
+
+describe('isValidUrl', () => {
+  describe('allowed protocols', () => {
+    it('accepts public https URLs', () => {
+      expect(isValidUrl('https://example.com/path?q=1')).toBe(true);
+    });
+
+    it('accepts public http URLs', () => {
+      expect(isValidUrl('http://example.com')).toBe(true);
+    });
+
+    it('accepts mailto URLs', () => {
+      expect(isValidUrl('mailto:foo@example.com')).toBe(true);
+    });
+  });
+
+  describe('rejected protocols', () => {
+    it.each([
+      'javascript:alert(1)',
+      'data:text/html,<script>alert(1)</script>',
+      'file:///etc/passwd',
+      'vbscript:msgbox(1)',
+      'ftp://example.com',
+      'chrome://settings',
+    ])('rejects %s', (url) => {
+      expect(isValidUrl(url)).toBe(false);
+    });
+  });
+
+  describe('private / internal hosts', () => {
+    it.each([
+      'http://localhost/',
+      'http://localhost:3000/',
+      'http://api.localhost/',
+      'http://127.0.0.1/',
+      'http://127.10.0.1/',
+      'http://10.0.0.1/',
+      'http://172.16.0.1/',
+      'http://172.31.255.255/',
+      'http://192.168.1.1/',
+      'http://169.254.169.254/', // AWS metadata
+      'http://0.0.0.0/',
+      'http://[::1]/',
+      'http://[fe80::1]/',
+      'http://[fc00::1]/',
+    ])('rejects %s', (url) => {
+      expect(isValidUrl(url)).toBe(false);
+    });
+
+    it('does not falsely flag public IPs', () => {
+      expect(isValidUrl('http://8.8.8.8/')).toBe(true);
+      expect(isValidUrl('http://172.32.0.1/')).toBe(true); // outside 172.16/12
+      expect(isValidUrl('http://172.15.0.1/')).toBe(true);
+    });
+  });
+
+  describe('malformed input', () => {
+    it.each(['', '   ', 'not a url', 'http://'])('rejects %s', (url) => {
+      expect(isValidUrl(url)).toBe(false);
+    });
+  });
+});
+
+describe('isValidPushEndpoint', () => {
+  it('accepts public https endpoint', () => {
+    expect(isValidPushEndpoint('https://fcm.googleapis.com/wp/abc')).toBe(true);
+  });
+
+  it('rejects http (non-https)', () => {
+    expect(isValidPushEndpoint('http://example.com/wp/abc')).toBe(false);
+  });
+
+  it('rejects private hosts even with https', () => {
+    expect(isValidPushEndpoint('https://localhost/abc')).toBe(false);
+    expect(isValidPushEndpoint('https://10.0.0.1/abc')).toBe(false);
+  });
+});

--- a/src/utils/urlValidation.ts
+++ b/src/utils/urlValidation.ts
@@ -1,12 +1,109 @@
 /**
- * URL が安全なプロトコルを使用しているか検証します
- * XSS攻撃を防ぐため、http/https/mailto のみを許可します
+ * URL が安全なプロトコルを使用しているか検証します。
+ *
+ * XSS / SSRF / フィッシング対策として以下を満たさない URL は拒否します:
+ *   - 許可プロトコル: `http`, `https`, `mailto` のみ
+ *     (`javascript:` / `data:` / `file:` / `vbscript:` 等を明示的に拒否)
+ *   - http/https の場合、ホストは公開到達可能な FQDN/IP であること
+ *     (`localhost` / loopback / private / link-local / unspecified を拒否)
+ *
+ * Push subscription endpoint や、ユーザーが入力する外部 URL に対して
+ * このユーティリティを通すことで、内部ネットワークへの SSRF を予防する。
  */
+
+const ALLOWED_PROTOCOLS = ['http:', 'https:', 'mailto:'] as const;
+
+const PRIVATE_HOSTNAMES = new Set([
+  'localhost',
+  'localhost.localdomain',
+  // IPv6 loopback の代表
+  '::1',
+  '[::1]',
+  // IPv4 unspecified
+  '0.0.0.0',
+]);
+
+function isPrivateIPv4(host: string): boolean {
+  // IPv4 リテラル判定: 4 オクテット数値であること。
+  const parts = host.split('.');
+  if (parts.length !== 4) return false;
+  const nums = parts.map((p) => {
+    if (!/^\d+$/.test(p)) return -1;
+    const n = Number(p);
+    return n >= 0 && n <= 255 ? n : -1;
+  });
+  if (nums.some((n) => n < 0)) return false;
+
+  const [a, b] = nums;
+  // 10.0.0.0/8
+  if (a === 10) return true;
+  // 127.0.0.0/8 (loopback)
+  if (a === 127) return true;
+  // 172.16.0.0/12
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  // 192.168.0.0/16
+  if (a === 192 && b === 168) return true;
+  // 169.254.0.0/16 (link-local)
+  if (a === 169 && b === 254) return true;
+  // 0.0.0.0/8 (unspecified)
+  if (a === 0) return true;
+  return false;
+}
+
+function isPrivateIPv6(host: string): boolean {
+  // URL.hostname は IPv6 を `[...]` で囲んで返す。両形式に対応。
+  const stripped = host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host;
+  const lower = stripped.toLowerCase();
+  if (lower === '::1' || lower === '::') return true;
+  // fc00::/7 (Unique Local) — `fc` または `fd` で始まる
+  if (/^fc[0-9a-f]{2}:/.test(lower) || /^fd[0-9a-f]{2}:/.test(lower)) return true;
+  // fe80::/10 (Link-local)
+  if (/^fe[89ab][0-9a-f]:/.test(lower)) return true;
+  return false;
+}
+
+function isPrivateHost(host: string): boolean {
+  if (!host) return true;
+  const lower = host.toLowerCase();
+  if (PRIVATE_HOSTNAMES.has(lower)) return true;
+  // `*.localhost` は RFC 6761 で常にループバックを指す
+  if (lower === 'localhost' || lower.endsWith('.localhost')) return true;
+  if (isPrivateIPv4(lower)) return true;
+  if (isPrivateIPv6(lower)) return true;
+  return false;
+}
+
 export function isValidUrl(url: string): boolean {
+  if (typeof url !== 'string' || url.trim() === '') return false;
+  let parsed: URL;
   try {
-    const parsedUrl = new URL(url);
-    const allowedProtocols = ['http:', 'https:', 'mailto:'];
-    return allowedProtocols.includes(parsedUrl.protocol);
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+
+  if (!ALLOWED_PROTOCOLS.includes(parsed.protocol as typeof ALLOWED_PROTOCOLS[number])) {
+    return false;
+  }
+
+  // mailto は host チェック対象外。
+  if (parsed.protocol === 'mailto:') return true;
+
+  // http/https はホストが必須かつ private 帯域でないこと。
+  if (!parsed.hostname) return false;
+  if (isPrivateHost(parsed.hostname)) return false;
+
+  return true;
+}
+
+/**
+ * Web Push の endpoint URL は公開された FCM/APNs/Mozilla AutoPush 等のホストに
+ * なっており、それ以外への SSRF を防ぐため `https://` を強制する。
+ */
+export function isValidPushEndpoint(endpoint: string): boolean {
+  if (!isValidUrl(endpoint)) return false;
+  try {
+    return new URL(endpoint).protocol === 'https:';
   } catch {
     return false;
   }

--- a/src/utils/urlValidation.ts
+++ b/src/utils/urlValidation.ts
@@ -16,9 +16,8 @@ const ALLOWED_PROTOCOLS = ['http:', 'https:', 'mailto:'] as const;
 const PRIVATE_HOSTNAMES = new Set([
   'localhost',
   'localhost.localdomain',
-  // IPv6 loopback の代表
+  // IPv6 loopback。URL.hostname は `[]` を外して返すのでブラケット無しで持つ。
   '::1',
-  '[::1]',
   // IPv4 unspecified
   '0.0.0.0',
 ]);
@@ -51,10 +50,22 @@ function isPrivateIPv4(host: string): boolean {
 }
 
 function isPrivateIPv6(host: string): boolean {
-  // URL.hostname は IPv6 を `[...]` で囲んで返す。両形式に対応。
+  // URL.hostname は IPv6 を `[...]` で囲んで返す場合と返さない場合があるので両対応。
   const stripped = host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host;
   const lower = stripped.toLowerCase();
   if (lower === '::1' || lower === '::') return true;
+
+  // IPv4-mapped IPv6 (::ffff:0:0/96)。WHATWG URL は埋め込み IPv4 を 2 つの 16bit
+  // hex グループに正規化する (例: `::ffff:7f00:1`)。SSRF を防ぐため hex グループを
+  // 復元して IPv4 の private 判定に委譲する。
+  const mapped = lower.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (mapped) {
+    const high = parseInt(mapped[1], 16);
+    const low = parseInt(mapped[2], 16);
+    const ipv4 = `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`;
+    return isPrivateIPv4(ipv4);
+  }
+
   // fc00::/7 (Unique Local) — `fc` または `fd` で始まる
   if (/^fc[0-9a-f]{2}:/.test(lower) || /^fd[0-9a-f]{2}:/.test(lower)) return true;
   // fe80::/10 (Link-local)
@@ -101,10 +112,7 @@ export function isValidUrl(url: string): boolean {
  * なっており、それ以外への SSRF を防ぐため `https://` を強制する。
  */
 export function isValidPushEndpoint(endpoint: string): boolean {
+  // isValidUrl が既に new URL の例外を吸収しているので、ここで再 try は不要。
   if (!isValidUrl(endpoint)) return false;
-  try {
-    return new URL(endpoint).protocol === 'https:';
-  } catch {
-    return false;
-  }
+  return new URL(endpoint).protocol === 'https:';
 }


### PR DESCRIPTION
## 概要

issue #92 のセキュリティタスク全 4 項目 (CSRF middleware 統合・zod 入力検証・URL バリデーション・サニタイゼーション) を一気に実装。PR #89 で追加した CSRF 基盤を全 mutation API に行き渡らせ、入力検証は zod に統一し、SSRF 対策と永続化境界でのサニタイズを追加した。

> ⚠️ **PR #89 とのマージ順序**: 本 PR は PR #89 (Web Push / CSRF 基盤) の `csrfToken.ts` などを前提にしているため、**PR #89 → 本 PR の順** にマージしてください。先に main にマージするとビルドが通りません。

## 主な変更

### CSRF を middleware で強制

- `middleware.ts` で `/api/*` の POST/PUT/PATCH/DELETE に対して `verifyCSRFAsync` を実行 (失敗時 403)
- 免除パス: `/api/csrf` / `/api/auth/callback` / `/api/cron/*`
- Edge runtime 互換のため Web Crypto API ベースの `csrfTokenEdge.ts` を新設 (既存の Node `crypto` ベースの `csrfToken.ts` はトークン生成・サーバー (Node) ルート用に維持)
- 既存ルートで個別に呼んでいた `verifyCSRF` は middleware 強制に置き換えて削除

### zod ベースの入力検証

- `pnpm add zod` (4.4.3)
- スキーマを `src/lib/validation/schemas.ts` に集約: `PreferencesUpdateSchema`, `PushSubscribeSchema`, `PushUnsubscribeSchema`, `ProfileUpdateSchema`, `SessionCreateSchema`, `ErrorLogsBatchSchema`
- 共通ヘルパー `parseJsonBody(request, schema)` を `src/lib/validation/parse.ts` に追加 → 各 route で `if (!parsed.ok) return parsed.response` の 1 行で完結
- 移行対象: `/api/preferences`, `/api/push/{subscribe,unsubscribe}`, `/api/auth/{session,profile/[userId]}`, `/api/logs/errors`
- 旧 `validateNotificationPreferences` / `validatePushSubscriptionFields` の手書きパスは撤去

### URL バリデーション強化

- `urlValidation.ts` で以下を **拒否**:
  - `javascript:` / `data:` / `file:` / `vbscript:` などの危険プロトコル
  - private IPv4: `10/8`, `127/8`, `172.16/12`, `192.168/16`, `169.254/16` (AWS metadata), `0/8`
  - IPv6 loopback (`::1`)、link-local (`fe80::/10`)、unique-local (`fc00::/7`)
  - `localhost` および `*.localhost`
- `isValidPushEndpoint` を追加し `PushSubscribeSchema` に組み込み → push endpoint の SSRF 予防

### サーバー側サニタイゼーション

- `src/utils/sanitize.ts` に `sanitizePlainText` を追加 (HTML タグ・コメント・制御文字を除去)
- 適用箇所: `/api/auth/profile/[userId]` PATCH の `name`、`/api/auth/session` POST の OAuth 由来 `googleName`

### クライアント fetch の CSRF 自動付与

- `src/lib/api/apiClient.ts` を新設: モジュール内でトークンをキャッシュし、mutation メソッドに `X-CSRF-Token` を自動付与。403 で 1 度だけ refresh してリトライ
- 既存の生 `fetch` 呼び出しを `apiFetch` に置換:
  - `src/stores/authStore.ts` (`/api/auth/logout`)
  - `src/hooks/useSessionManager.ts` (`/api/auth/session`)
  - `src/app/profile/page.tsx` (`/api/auth/profile/[id]`)
  - `src/services/errorLoggingService.ts` (`/api/logs/errors`)
  - `src/lib/errorTracking/client.ts` (`/api/logs/errors`)

### テスト追加

- `middleware.test.ts` — 403 / exempt / mutating-only の matrix
- `src/utils/csrfTokenEdge.test.ts` — Web Crypto 版の検証 6 ケース
- `src/utils/urlValidation.test.ts` — 許可/拒否プロトコル + private 帯域 + push endpoint 専用
- `src/utils/sanitize.test.ts` — タグ・コメント・制御文字除去
- `src/lib/validation/schemas.test.ts` — 各スキーマの正常 / 異常系
- `src/lib/validation/parse.test.ts` — JSON エラー / 検証エラーのレスポンス整形
- `src/lib/api/apiClient.test.ts` — トークン取得・キャッシュ・403 リトライ

### 既存テストの更新

- 各 route の `vi.mock('@/utils/csrfToken', ...)` を撤去 (CSRF は middleware で別途テスト)
- 文字列完全一致だった error assertion を `expect(typeof data.error).toBe('string')` 等に緩めた (zod 生成メッセージ許容)

## 動作確認

- [x] `pnpm test:run` — 全 633 件中 632 passed (失敗した 1 件は main 単独でも fail する `authStore` の既存テスト)
- [x] `pnpm exec tsc --noEmit` — 11 errors (main 単独では 12)。新規ファイルにエラーなし
- [x] `pnpm lint` — 新規・変更ファイルにエラーなし (既存 45 errors は本 PR 範囲外)

## 必要な環境変数 (再掲)

- `CSRF_SECRET` — 16 文字以上の HMAC 用シークレット (middleware が起動時に検証)

## issue #92 のチェックリスト対応

- [x] middleware で CSRF 強制
- [x] 全 mutation route に CSRF 適用 (個別ルートではなく middleware で一律)
- [x] zod 導入とスキーマ定義
- [x] URL バリデーション強化 (private IP / loopback / file:// / javascript: / data:)
- [x] サニタイゼーション見直し (サーバー側 plain text サニタイザ追加)
- [x] テスト追加 (CSRF 不正・スキーマ不一致)

Closes #92


---
_Generated by [Claude Code](https://claude.ai/code/session_01B7EJeV6o3fnqoZTP35nL4o)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security Improvements**
  * Added CSRF protection to API mutations
  * Enhanced input validation and sanitization across profile, preferences, and session APIs
  * Enforced stricter URL validation for push endpoints (HTTPS required, private hosts rejected)

* **Improvements**
  * Automatic CSRF token handling on client requests for seamless security
  * More consistent and structured validation error responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->