### PR TITLE
feat(#90): 通知設定を「配信曜日」モデルに刷新

### DIFF
--- a/database/notification-preferences-weekday.sql
+++ b/database/notification-preferences-weekday.sql
@@ -19,7 +19,15 @@ ALTER TABLE user_preferences
   ALTER COLUMN notification_preferences
   SET DEFAULT '{"reminder_weekday": null}'::jsonb;
 
--- 2) 既存行を OFF にリセット
+-- 2) 旧モデルの行だけを OFF にリセットする。
+-- 旧フォーマット (daily_reminder 等のキーを持つ行) のみを対象にすることで、
+-- スクリプトを再実行しても、既に新モデルへ移行済み (reminder_weekday を設定済み)
+-- のユーザーの選択を上書きしない。
 UPDATE user_preferences
   SET notification_preferences = '{"reminder_weekday": null}'::jsonb
-  WHERE notification_preferences IS DISTINCT FROM '{"reminder_weekday": null}'::jsonb;
+  WHERE notification_preferences ?| ARRAY[
+    'daily_reminder',
+    'weekly_summary',
+    'reminder_time',
+    'achievement_alerts'
+  ];

--- a/database/notification-preferences-weekday.sql
+++ b/database/notification-preferences-weekday.sql
@@ -1,0 +1,25 @@
+-- notification_preferences を「配信曜日」モデルへ移行する。
+--
+-- 旧モデル: { daily_reminder, reminder_time, weekly_summary, achievement_alerts }
+-- 新モデル: { reminder_weekday: 0-6 | null }   (0=日曜〜6=土曜、null = OFF)
+--
+-- 配信時刻は JST 11:00 固定 (Vercel Cron `0 2 * * *` UTC) になったため、
+-- ユーザー設定は「配信する曜日」だけになる。
+--
+-- 既存行は OFF (reminder_weekday: null) に初期化する。
+-- 旧 reminder_time には曜日の情報が無く、daily(毎日)/weekly(週1) の区別から
+-- 曜日を一意に決められないため、移行ではなく一律リセットとし、ユーザーに
+-- 再設定してもらう方針。
+--
+-- 既存テーブルが前提なので、GRANT は push-subscriptions-and-preferences.sql で
+-- 付与済み (ここでは追加不要)。
+
+-- 1) デフォルト値を新モデルに変更
+ALTER TABLE user_preferences
+  ALTER COLUMN notification_preferences
+  SET DEFAULT '{"reminder_weekday": null}'::jsonb;
+
+-- 2) 既存行を OFF にリセット
+UPDATE user_preferences
+  SET notification_preferences = '{"reminder_weekday": null}'::jsonb
+  WHERE notification_preferences IS DISTINCT FROM '{"reminder_weekday": null}'::jsonb;

--- a/database/push-subscriptions-and-preferences.sql
+++ b/database/push-subscriptions-and-preferences.sql
@@ -69,10 +69,7 @@ CREATE TABLE IF NOT EXISTS user_preferences (
   pwa_install_dismissed BOOLEAN NOT NULL DEFAULT false,
   timezone TEXT NOT NULL DEFAULT 'Asia/Tokyo',
   notification_preferences JSONB NOT NULL DEFAULT '{
-    "daily_reminder": false,
-    "reminder_time": "20:00",
-    "weekly_summary": false,
-    "achievement_alerts": true
+    "reminder_weekday": null
   }'::JSONB,
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now()

--- a/src/app/api/preferences/route.test.ts
+++ b/src/app/api/preferences/route.test.ts
@@ -23,10 +23,7 @@ const mockPreferences = {
   pwa_install_dismissed: false,
   timezone: 'Asia/Tokyo',
   notification_preferences: {
-    daily_reminder: false,
-    reminder_time: '20:00',
-    weekly_summary: false,
-    achievement_alerts: true,
+    reminder_weekday: null,
   },
   created_at: '2026-04-19T00:00:00Z',
   updated_at: '2026-04-19T00:00:00Z',
@@ -180,7 +177,7 @@ describe('PUT /api/preferences', () => {
       ...mockPreferences,
       notification_preferences: {
         ...mockPreferences.notification_preferences,
-        daily_reminder: true,
+        reminder_weekday: 2,
       },
     };
     const singleFn = vi.fn().mockResolvedValue({ data: updatedPrefs, error: null });
@@ -195,11 +192,10 @@ describe('PUT /api/preferences', () => {
       .mockReturnValueOnce(existingChain)
       .mockReturnValueOnce(updateChain);
 
-    const res = await PUT(makePutRequest({ notification_preferences: { daily_reminder: true } }));
+    const res = await PUT(makePutRequest({ notification_preferences: { reminder_weekday: 2 } }));
     expect(res.status).toBe(200);
 
     const json = await res.json();
-    expect(json.preferences.notification_preferences.daily_reminder).toBe(true);
-    expect(json.preferences.notification_preferences.achievement_alerts).toBe(true);
+    expect(json.preferences.notification_preferences.reminder_weekday).toBe(2);
   });
 });

--- a/src/app/api/preferences/route.ts
+++ b/src/app/api/preferences/route.ts
@@ -8,10 +8,7 @@ const DEFAULT_PREFERENCES = {
   pwa_install_dismissed: false,
   timezone: 'Asia/Tokyo',
   notification_preferences: {
-    daily_reminder: false,
-    reminder_time: '20:00',
-    weekly_summary: false,
-    achievement_alerts: true,
+    reminder_weekday: null,
   } as NotificationPreferences,
 };
 

--- a/src/app/profile/page.test.tsx
+++ b/src/app/profile/page.test.tsx
@@ -23,6 +23,11 @@ vi.mock('@/components/profile/ProfileCard', () => ({
   ),
 }));
 
+// Mock NotificationSettings component
+vi.mock('@/components/profile/NotificationSettings', () => ({
+  NotificationSettings: () => <div data-testid="notification-settings" />,
+}));
+
 // Mock Header component
 vi.mock('@/components/layout/Header', () => ({
   default: ({ title }: { title: string }) => <div data-testid="header">{title}</div>,

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/hooks/useAuth';
 import { ProfileCard } from '@/components/profile/ProfileCard';
+import { NotificationSettings } from '@/components/profile/NotificationSettings';
 import Header from '@/components/layout/Header';
 import DashboardLoading from '../dashboard/loading';
 import { FadeIn } from '@/components/animations/FadeIn';
@@ -105,6 +106,12 @@ export default function ProfilePage() {
             onUpdateProfile={handleUpdateProfile}
             isUpdating={isUpdating}
           />
+        </FadeIn>
+
+        <FadeIn duration={400}>
+          <div className="mt-6">
+            <NotificationSettings />
+          </div>
         </FadeIn>
       </main>
     </div>

--- a/src/components/profile/NotificationSettings.test.tsx
+++ b/src/components/profile/NotificationSettings.test.tsx
@@ -1,29 +1,36 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
-const { mockApiFetch, mockShowToast, pushClient, pwa } = vi.hoisted(() => ({
-  mockApiFetch: vi.fn(),
-  mockShowToast: vi.fn(),
-  pushClient: {
-    isPushSupported: vi.fn(() => true),
-    requestPushPermission: vi.fn(async () => 'granted'),
-    subscribeToPush: vi.fn(async () => ({
-      endpoint: 'https://push.example/abc',
-      p256dh: 'p256',
-      auth: 'authkey',
-    })),
-    unsubscribeFromPush: vi.fn(async () => 'https://push.example/abc'),
-  },
-  pwa: {
-    isIOSDevice: vi.fn(() => false),
-    isStandaloneDisplay: vi.fn(() => false),
-  },
-}));
+const { mockApiFetch, mockShowToast, pushClient, pwa, installState, mockPromptInstall } =
+  vi.hoisted(() => ({
+    mockApiFetch: vi.fn(),
+    mockShowToast: vi.fn(),
+    mockPromptInstall: vi.fn(async () => 'accepted' as const),
+    pushClient: {
+      isPushSupported: vi.fn(() => true),
+      requestPushPermission: vi.fn(async () => 'granted'),
+      subscribeToPush: vi.fn(async () => ({
+        endpoint: 'https://push.example/abc',
+        p256dh: 'p256',
+        auth: 'authkey',
+      })),
+      unsubscribeFromPush: vi.fn(async () => 'https://push.example/abc'),
+    },
+    pwa: {
+      isIOSDevice: vi.fn(() => false),
+      isStandaloneDisplay: vi.fn(() => false),
+    },
+    // useInstallPrompt の戻り値。テストごとに書き換える。
+    installState: { isInstalled: false, canInstall: false, isPrompting: false },
+  }));
 
 vi.mock('@/lib/api/apiClient', () => ({ apiFetch: mockApiFetch }));
 vi.mock('@/hooks/useToast', () => ({ useToast: () => ({ showToast: mockShowToast }) }));
 vi.mock('@/lib/push/client', () => pushClient);
 vi.mock('@/lib/pwa/standalone', () => pwa);
+vi.mock('@/hooks/useInstallPrompt', () => ({
+  useInstallPrompt: () => ({ ...installState, promptInstall: mockPromptInstall }),
+}));
 
 import { NotificationSettings } from './NotificationSettings';
 
@@ -54,30 +61,52 @@ describe('NotificationSettings', () => {
     pushClient.unsubscribeFromPush.mockResolvedValue('https://push.example/abc');
     pwa.isIOSDevice.mockReturnValue(false);
     pwa.isStandaloneDisplay.mockReturnValue(false);
+    installState.isInstalled = false;
+    installState.canInstall = false;
+    installState.isPrompting = false;
   });
 
-  it('always shows the install requirement note', async () => {
+  it('shows the install guidance when not installed', async () => {
     mockPreferencesApi(null);
     render(<NotificationSettings />);
     await waitFor(() => expect(getSelect()).toBeInTheDocument());
-    expect(screen.getByText('📱 プッシュ通知を受け取るには')).toBeInTheDocument();
+    expect(
+      await screen.findByText('📱 通知を受け取るにはインストールが必要です'),
+    ).toBeInTheDocument();
   });
 
-  it('warns iOS users who have not installed the app to the home screen', async () => {
-    pwa.isIOSDevice.mockReturnValue(true);
-    pwa.isStandaloneDisplay.mockReturnValue(false);
-    mockPreferencesApi(null);
-    render(<NotificationSettings />);
-    expect(await screen.findByRole('alert')).toHaveTextContent('ホーム画面に追加');
-  });
-
-  it('does not warn when running as an installed PWA on iOS', async () => {
-    pwa.isIOSDevice.mockReturnValue(true);
-    pwa.isStandaloneDisplay.mockReturnValue(true);
+  it('hides the install guidance when already installed', async () => {
+    installState.isInstalled = true;
     mockPreferencesApi(2);
     render(<NotificationSettings />);
     await waitFor(() => expect(getSelect()).toBeInTheDocument());
-    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('📱 通知を受け取るにはインストールが必要です'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows iOS home-screen steps when not installed on iOS without an install prompt', async () => {
+    pwa.isIOSDevice.mockReturnValue(true);
+    installState.canInstall = false;
+    mockPreferencesApi(null);
+    render(<NotificationSettings />);
+    expect(await screen.findByText('「ホーム画面に追加」を選択')).toBeInTheDocument();
+  });
+
+  it('triggers the install prompt when the install button is clicked', async () => {
+    installState.canInstall = true;
+    mockPromptInstall.mockResolvedValue('accepted');
+    mockPreferencesApi(null);
+    render(<NotificationSettings />);
+
+    const installButton = await screen.findByRole('button', { name: 'アプリをインストール' });
+    fireEvent.click(installButton);
+
+    await waitFor(() => expect(mockPromptInstall).toHaveBeenCalled());
+    expect(mockShowToast).toHaveBeenCalledWith(
+      'インストールしました。通知を有効にできます。',
+      'success',
+    );
   });
 
   it('loads and shows the current reminder weekday', async () => {

--- a/src/components/profile/NotificationSettings.test.tsx
+++ b/src/components/profile/NotificationSettings.test.tsx
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const { mockApiFetch, mockShowToast, pushClient } = vi.hoisted(() => ({
+  mockApiFetch: vi.fn(),
+  mockShowToast: vi.fn(),
+  pushClient: {
+    isPushSupported: vi.fn(() => true),
+    requestPushPermission: vi.fn(async () => 'granted'),
+    subscribeToPush: vi.fn(async () => ({
+      endpoint: 'https://push.example/abc',
+      p256dh: 'p256',
+      auth: 'authkey',
+    })),
+    unsubscribeFromPush: vi.fn(async () => 'https://push.example/abc'),
+  },
+}));
+
+vi.mock('@/lib/api/apiClient', () => ({ apiFetch: mockApiFetch }));
+vi.mock('@/hooks/useToast', () => ({ useToast: () => ({ showToast: mockShowToast }) }));
+vi.mock('@/lib/push/client', () => pushClient);
+
+import { NotificationSettings } from './NotificationSettings';
+
+/** apiFetch のデフォルト挙動: GET /api/preferences は指定 weekday を返し、それ以外は ok。 */
+function mockPreferencesApi(reminderWeekday: number | null) {
+  mockApiFetch.mockImplementation((url: string, init?: { method?: string }) => {
+    const method = init?.method ?? 'GET';
+    if (url === '/api/preferences' && method === 'GET') {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          preferences: { notification_preferences: { reminder_weekday: reminderWeekday } },
+        }),
+      });
+    }
+    return Promise.resolve({ ok: true, json: async () => ({}) });
+  });
+}
+
+const getSelect = () => screen.getByLabelText('通知する曜日') as HTMLSelectElement;
+
+describe('NotificationSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY = 'test-vapid-key';
+    pushClient.isPushSupported.mockReturnValue(true);
+    pushClient.requestPushPermission.mockResolvedValue('granted');
+    pushClient.unsubscribeFromPush.mockResolvedValue('https://push.example/abc');
+  });
+
+  it('loads and shows the current reminder weekday', async () => {
+    mockPreferencesApi(2); // 火曜日
+    render(<NotificationSettings />);
+
+    await waitFor(() => expect(getSelect()).toBeInTheDocument());
+    expect(getSelect().value).toBe('2');
+  });
+
+  it('shows an error message when loading fails', async () => {
+    mockApiFetch.mockResolvedValue({ ok: false, json: async () => ({}) });
+    render(<NotificationSettings />);
+
+    expect(await screen.findByText('通知設定の取得に失敗しました。')).toBeInTheDocument();
+  });
+
+  it('keeps the save button disabled until the value changes', async () => {
+    mockPreferencesApi(null); // OFF
+    render(<NotificationSettings />);
+
+    await waitFor(() => expect(getSelect()).toBeInTheDocument());
+    const saveButton = screen.getByRole('button', { name: '保存' });
+    expect(saveButton).toBeDisabled();
+
+    fireEvent.change(getSelect(), { target: { value: '3' } });
+    expect(saveButton).not.toBeDisabled();
+  });
+
+  it('subscribes to push and persists the weekday when enabling', async () => {
+    mockPreferencesApi(null); // OFF 初期
+    render(<NotificationSettings />);
+    await waitFor(() => expect(getSelect()).toBeInTheDocument());
+
+    fireEvent.change(getSelect(), { target: { value: '1' } }); // 月曜日
+    fireEvent.click(screen.getByRole('button', { name: '保存' }));
+
+    await waitFor(() => {
+      expect(pushClient.subscribeToPush).toHaveBeenCalled();
+    });
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      '/api/push/subscribe',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      '/api/preferences',
+      expect.objectContaining({
+        method: 'PUT',
+        body: expect.stringContaining('"reminder_weekday":1'),
+      }),
+    );
+    expect(mockShowToast).toHaveBeenCalledWith('通知設定を保存しました。', 'success');
+  });
+
+  it('unsubscribes from push and persists null when turning OFF', async () => {
+    mockPreferencesApi(3); // 水曜日 初期
+    render(<NotificationSettings />);
+    await waitFor(() => expect(getSelect().value).toBe('3'));
+
+    fireEvent.change(getSelect(), { target: { value: '' } }); // OFF
+    fireEvent.click(screen.getByRole('button', { name: '保存' }));
+
+    await waitFor(() => {
+      expect(pushClient.unsubscribeFromPush).toHaveBeenCalled();
+    });
+    expect(pushClient.subscribeToPush).not.toHaveBeenCalled();
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      '/api/preferences',
+      expect.objectContaining({
+        method: 'PUT',
+        body: expect.stringContaining('"reminder_weekday":null'),
+      }),
+    );
+  });
+
+  it('does not subscribe when the browser is unsupported', async () => {
+    mockPreferencesApi(null);
+    pushClient.isPushSupported.mockReturnValue(false);
+    render(<NotificationSettings />);
+    await waitFor(() => expect(getSelect()).toBeInTheDocument());
+
+    fireEvent.change(getSelect(), { target: { value: '1' } });
+    fireEvent.click(screen.getByRole('button', { name: '保存' }));
+
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith(
+        'このブラウザはプッシュ通知に対応していません。',
+        'error',
+      );
+    });
+    expect(pushClient.subscribeToPush).not.toHaveBeenCalled();
+    // preferences PUT も呼ばれない (enable 失敗で早期 return)
+    expect(mockApiFetch).not.toHaveBeenCalledWith(
+      '/api/preferences',
+      expect.objectContaining({ method: 'PUT' }),
+    );
+  });
+});

--- a/src/components/profile/NotificationSettings.test.tsx
+++ b/src/components/profile/NotificationSettings.test.tsx
@@ -70,9 +70,7 @@ describe('NotificationSettings', () => {
     mockPreferencesApi(null);
     render(<NotificationSettings />);
     await waitFor(() => expect(getSelect()).toBeInTheDocument());
-    expect(
-      await screen.findByText('📱 通知を受け取るにはインストールが必要です'),
-    ).toBeInTheDocument();
+    expect(await screen.findByTestId('install-guidance')).toBeInTheDocument();
   });
 
   it('hides the install guidance when already installed', async () => {
@@ -80,17 +78,28 @@ describe('NotificationSettings', () => {
     mockPreferencesApi(2);
     render(<NotificationSettings />);
     await waitFor(() => expect(getSelect()).toBeInTheDocument());
-    expect(
-      screen.queryByText('📱 通知を受け取るにはインストールが必要です'),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId('install-guidance')).not.toBeInTheDocument();
   });
 
-  it('shows iOS home-screen steps when not installed on iOS without an install prompt', async () => {
+  it('frames install as required on iOS (not installed)', async () => {
     pwa.isIOSDevice.mockReturnValue(true);
     installState.canInstall = false;
     mockPreferencesApi(null);
     render(<NotificationSettings />);
-    expect(await screen.findByText('「ホーム画面に追加」を選択')).toBeInTheDocument();
+    expect(
+      await screen.findByText('📱 通知を受け取るにはインストールが必要です'),
+    ).toBeInTheDocument();
+    // iOS かつ prompt 不可 → ホーム画面追加の手順を表示
+    expect(screen.getByText('「ホーム画面に追加」を選択')).toBeInTheDocument();
+  });
+
+  it('frames install as optional on non-iOS (notifications work without it)', async () => {
+    pwa.isIOSDevice.mockReturnValue(false);
+    mockPreferencesApi(null);
+    render(<NotificationSettings />);
+    expect(
+      await screen.findByText('📱 アプリをインストールすると、より確実に通知を受け取れます'),
+    ).toBeInTheDocument();
   });
 
   it('triggers the install prompt when the install button is clicked', async () => {

--- a/src/components/profile/NotificationSettings.test.tsx
+++ b/src/components/profile/NotificationSettings.test.tsx
@@ -213,4 +213,34 @@ describe('NotificationSettings', () => {
       expect.objectContaining({ method: 'PUT' }),
     );
   });
+
+  it('re-syncs the UI to the saved value when persisting fails', async () => {
+    // GET は OFF を返し、PUT は失敗させる。
+    mockApiFetch.mockImplementation((url: string, init?: { method?: string }) => {
+      const method = init?.method ?? 'GET';
+      if (url === '/api/preferences' && method === 'GET') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            preferences: { notification_preferences: { reminder_weekday: null } },
+          }),
+        });
+      }
+      if (url === '/api/preferences' && method === 'PUT') {
+        return Promise.resolve({ ok: false, json: async () => ({ error: '保存に失敗しました' }) });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+
+    render(<NotificationSettings />);
+    await waitFor(() => expect(getSelect()).toBeInTheDocument());
+
+    fireEvent.change(getSelect(), { target: { value: '1' } });
+    expect(getSelect().value).toBe('1');
+    fireEvent.click(screen.getByRole('button', { name: '保存' }));
+
+    await waitFor(() => expect(mockShowToast).toHaveBeenCalledWith('保存に失敗しました', 'error'));
+    // 失敗後はサーバの保存値 (OFF) に戻る
+    await waitFor(() => expect(getSelect().value).toBe(''));
+  });
 });

--- a/src/components/profile/NotificationSettings.test.tsx
+++ b/src/components/profile/NotificationSettings.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
-const { mockApiFetch, mockShowToast, pushClient } = vi.hoisted(() => ({
+const { mockApiFetch, mockShowToast, pushClient, pwa } = vi.hoisted(() => ({
   mockApiFetch: vi.fn(),
   mockShowToast: vi.fn(),
   pushClient: {
@@ -14,11 +14,16 @@ const { mockApiFetch, mockShowToast, pushClient } = vi.hoisted(() => ({
     })),
     unsubscribeFromPush: vi.fn(async () => 'https://push.example/abc'),
   },
+  pwa: {
+    isIOSDevice: vi.fn(() => false),
+    isStandaloneDisplay: vi.fn(() => false),
+  },
 }));
 
 vi.mock('@/lib/api/apiClient', () => ({ apiFetch: mockApiFetch }));
 vi.mock('@/hooks/useToast', () => ({ useToast: () => ({ showToast: mockShowToast }) }));
 vi.mock('@/lib/push/client', () => pushClient);
+vi.mock('@/lib/pwa/standalone', () => pwa);
 
 import { NotificationSettings } from './NotificationSettings';
 
@@ -47,6 +52,32 @@ describe('NotificationSettings', () => {
     pushClient.isPushSupported.mockReturnValue(true);
     pushClient.requestPushPermission.mockResolvedValue('granted');
     pushClient.unsubscribeFromPush.mockResolvedValue('https://push.example/abc');
+    pwa.isIOSDevice.mockReturnValue(false);
+    pwa.isStandaloneDisplay.mockReturnValue(false);
+  });
+
+  it('always shows the install requirement note', async () => {
+    mockPreferencesApi(null);
+    render(<NotificationSettings />);
+    await waitFor(() => expect(getSelect()).toBeInTheDocument());
+    expect(screen.getByText('📱 プッシュ通知を受け取るには')).toBeInTheDocument();
+  });
+
+  it('warns iOS users who have not installed the app to the home screen', async () => {
+    pwa.isIOSDevice.mockReturnValue(true);
+    pwa.isStandaloneDisplay.mockReturnValue(false);
+    mockPreferencesApi(null);
+    render(<NotificationSettings />);
+    expect(await screen.findByRole('alert')).toHaveTextContent('ホーム画面に追加');
+  });
+
+  it('does not warn when running as an installed PWA on iOS', async () => {
+    pwa.isIOSDevice.mockReturnValue(true);
+    pwa.isStandaloneDisplay.mockReturnValue(true);
+    mockPreferencesApi(2);
+    render(<NotificationSettings />);
+    await waitFor(() => expect(getSelect()).toBeInTheDocument());
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 
   it('loads and shows the current reminder weekday', async () => {

--- a/src/components/profile/NotificationSettings.tsx
+++ b/src/components/profile/NotificationSettings.tsx
@@ -174,14 +174,32 @@ export function NotificationSettings() {
         毎週、選択した曜日の朝 11:00（日本時間）に振り返りのリマインダーをお送りします。
       </p>
 
-      {/* すでにホーム画面に追加 (standalone) 済みなら案内は出さない。 */}
+      {/* すでにホーム画面に追加 (standalone) 済みなら案内は出さない。
+          iOS はインストール必須なので amber で強調、それ以外は任意なので gray で案内。 */}
       {mounted && !isInstalled && (
-        <div className="mt-3 rounded-md bg-amber-50 border border-amber-200 p-3 text-xs text-amber-800">
-          <p className="font-medium">📱 通知を受け取るにはインストールが必要です</p>
-          <p className="mt-1">
-            ReflectHub をホーム画面に追加（インストール）したアプリから通知を受け取れます。
-            {isIOS && ' iPhone / iPad では、Safari のタブからは通知を受け取れません。'}
-          </p>
+        <div
+          data-testid="install-guidance"
+          className={
+            isIOS
+              ? 'mt-3 rounded-md bg-amber-50 border border-amber-200 p-3 text-xs text-amber-800'
+              : 'mt-3 rounded-md bg-gray-50 border border-gray-200 p-3 text-xs text-gray-600'
+          }
+        >
+          {isIOS ? (
+            <>
+              <p className="font-medium">📱 通知を受け取るにはインストールが必要です</p>
+              <p className="mt-1">
+                iPhone / iPad では、ホーム画面に追加したアプリでのみ通知を受け取れます（Safari のタブでは受け取れません）。
+              </p>
+            </>
+          ) : (
+            <>
+              <p className="font-medium text-gray-700">📱 アプリをインストールすると、より確実に通知を受け取れます</p>
+              <p className="mt-1">
+                ホーム画面に追加するとアプリのように起動でき、通知も安定します。インストールしなくても通知は利用できます。
+              </p>
+            </>
+          )}
           {canInstall ? (
             <div className="mt-2">
               <Button size="sm" onClick={handleInstall} disabled={isPrompting}>

--- a/src/components/profile/NotificationSettings.tsx
+++ b/src/components/profile/NotificationSettings.tsx
@@ -10,7 +10,8 @@ import {
   subscribeToPush,
   unsubscribeFromPush,
 } from '@/lib/push/client';
-import { isIOSDevice, isStandaloneDisplay } from '@/lib/pwa/standalone';
+import { isIOSDevice } from '@/lib/pwa/standalone';
+import { useInstallPrompt } from '@/hooks/useInstallPrompt';
 import type { NotificationPreferences } from '@/types/push';
 
 /** OFF を表す select の値 (空文字)。曜日は '0'〜'6'。 */
@@ -45,17 +46,20 @@ function weekdayToValue(weekday: number | null | undefined): string {
  */
 export function NotificationSettings() {
   const { showToast } = useToast();
+  const { isInstalled, canInstall, isPrompting, promptInstall } = useInstallPrompt();
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [weekday, setWeekday] = useState<string>(OFF_VALUE);
   const [savedWeekday, setSavedWeekday] = useState<string>(OFF_VALUE);
-  // ホーム画面に追加した PWA でないと通知を受け取れない (特に iOS)。
-  // UA/standalone 判定は SSR では走らせず、マウント後に評価する。
-  const [needsInstallForIOS, setNeedsInstallForIOS] = useState(false);
+  // インストール状態と UA 判定は SSR と一致しないため、マウント後に評価する
+  // (hydration mismatch を避けるため、確定するまで案内を描画しない)。
+  const [mounted, setMounted] = useState(false);
+  const [isIOS, setIsIOS] = useState(false);
 
   useEffect(() => {
-    setNeedsInstallForIOS(isIOSDevice() && !isStandaloneDisplay());
+    setMounted(true);
+    setIsIOS(isIOSDevice());
   }, []);
 
   useEffect(() => {
@@ -121,6 +125,13 @@ export function NotificationSettings() {
     });
   }, []);
 
+  const handleInstall = useCallback(async () => {
+    const outcome = await promptInstall();
+    if (outcome === 'accepted') {
+      showToast('インストールしました。通知を有効にできます。', 'success');
+    }
+  }, [promptInstall, showToast]);
+
   const handleSave = useCallback(async () => {
     setSaving(true);
     try {
@@ -163,18 +174,27 @@ export function NotificationSettings() {
         毎週、選択した曜日の朝 11:00（日本時間）に振り返りのリマインダーをお送りします。
       </p>
 
-      <div className="mt-3 rounded-md bg-gray-50 border border-gray-200 p-3 text-xs text-gray-600">
-        <p className="font-medium text-gray-700">📱 プッシュ通知を受け取るには</p>
-        <p className="mt-1">
-          ReflectHub を<strong>ホーム画面に追加（インストール）</strong>したアプリから通知を受け取れます。
-          特に iPhone / iPad では、ホーム画面に追加したアプリでのみ通知が有効で、Safari のタブからは受け取れません。
-        </p>
-      </div>
-
-      {needsInstallForIOS && (
-        <div className="mt-3 rounded-md bg-amber-50 border border-amber-200 p-3 text-xs text-amber-800" role="alert">
-          お使いの端末ではまだホーム画面に追加されていないようです。
-          共有メニューから「ホーム画面に追加」でインストールしてから通知を有効にしてください。
+      {/* すでにホーム画面に追加 (standalone) 済みなら案内は出さない。 */}
+      {mounted && !isInstalled && (
+        <div className="mt-3 rounded-md bg-amber-50 border border-amber-200 p-3 text-xs text-amber-800">
+          <p className="font-medium">📱 通知を受け取るにはインストールが必要です</p>
+          <p className="mt-1">
+            ReflectHub をホーム画面に追加（インストール）したアプリから通知を受け取れます。
+            {isIOS && ' iPhone / iPad では、Safari のタブからは通知を受け取れません。'}
+          </p>
+          {canInstall ? (
+            <div className="mt-2">
+              <Button size="sm" onClick={handleInstall} disabled={isPrompting}>
+                {isPrompting ? 'インストール中…' : 'アプリをインストール'}
+              </Button>
+            </div>
+          ) : isIOS ? (
+            <ol className="mt-2 list-decimal space-y-0.5 pl-4">
+              <li>Safari の共有ボタン（□に↑）をタップ</li>
+              <li>「ホーム画面に追加」を選択</li>
+              <li>追加したアイコンからアプリを開く</li>
+            </ol>
+          ) : null}
         </div>
       )}
 

--- a/src/components/profile/NotificationSettings.tsx
+++ b/src/components/profile/NotificationSettings.tsx
@@ -63,17 +63,22 @@ export function NotificationSettings() {
     setIsIOS(isIOSDevice());
   }, []);
 
+  /** サーバから現在の保存済み reminder_weekday を取得して select の値に変換する。 */
+  const fetchSavedWeekday = useCallback(async (): Promise<string> => {
+    const res = await apiFetch('/api/preferences');
+    if (!res.ok) throw new Error('通知設定の取得に失敗しました。');
+    const data = (await res.json()) as {
+      preferences?: { notification_preferences?: NotificationPreferences };
+    };
+    return weekdayToValue(data.preferences?.notification_preferences?.reminder_weekday);
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
-        const res = await apiFetch('/api/preferences');
-        if (!res.ok) throw new Error('通知設定の取得に失敗しました。');
-        const data = (await res.json()) as {
-          preferences?: { notification_preferences?: NotificationPreferences };
-        };
+        const value = await fetchSavedWeekday();
         if (cancelled) return;
-        const value = weekdayToValue(data.preferences?.notification_preferences?.reminder_weekday);
         setWeekday(value);
         setSavedWeekday(value);
       } catch (err) {
@@ -86,7 +91,7 @@ export function NotificationSettings() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [fetchSavedWeekday]);
 
   const enablePush = useCallback(async (): Promise<boolean> => {
     if (!isPushSupported()) {
@@ -119,11 +124,27 @@ export function NotificationSettings() {
   const disablePush = useCallback(async (): Promise<void> => {
     const endpoint = await unsubscribeFromPush();
     if (!endpoint) return;
-    await apiFetch('/api/push/unsubscribe', {
+    const res = await apiFetch('/api/push/unsubscribe', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ endpoint }),
     });
+    if (!res.ok) {
+      const body = (await res.json().catch(() => ({}))) as { error?: string };
+      throw new Error(body.error || 'プッシュ通知の解除に失敗しました。');
+    }
+  }, []);
+
+  const savePreference = useCallback(async (reminderWeekday: number | null): Promise<void> => {
+    const res = await apiFetch('/api/preferences', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ notification_preferences: { reminder_weekday: reminderWeekday } }),
+    });
+    if (!res.ok) {
+      const body = (await res.json().catch(() => ({}))) as { error?: string };
+      throw new Error(body.error || '通知設定の保存に失敗しました。');
+    }
   }, []);
 
   const handleInstall = useCallback(async () => {
@@ -138,31 +159,35 @@ export function NotificationSettings() {
     try {
       const reminderWeekday = weekday === OFF_VALUE ? null : Number(weekday);
 
+      // ブラウザの購読解除はクライアント操作で DB と真にアトミックにはできないため、
+      // cron の唯一の真実である reminder_weekday (DB) と購読状態が極力ずれない順序にする。
       if (reminderWeekday !== null) {
+        // 有効化: 先に購読を確立してから保存する (購読が無いまま「ON」を永続化しない)。
         const ok = await enablePush();
         if (!ok) return;
+        await savePreference(reminderWeekday);
       } else {
+        // 無効化: 先に DB を OFF にしてから購読解除する (解除が失敗しても誤配信しない)。
+        await savePreference(reminderWeekday);
         await disablePush();
-      }
-
-      const res = await apiFetch('/api/preferences', {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ notification_preferences: { reminder_weekday: reminderWeekday } }),
-      });
-      if (!res.ok) {
-        const body = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(body.error || '通知設定の保存に失敗しました。');
       }
 
       setSavedWeekday(weekday);
       showToast('通知設定を保存しました。', 'success');
     } catch (err) {
       showToast(err instanceof Error ? err.message : '通知設定の保存に失敗しました。', 'error');
+      // 部分的失敗で表示と実状態が乖離しないよう、保存済みの値に UI を再同期する。
+      try {
+        const value = await fetchSavedWeekday();
+        setWeekday(value);
+        setSavedWeekday(value);
+      } catch {
+        // 再同期にも失敗した場合は元のエラー表示を優先し、ここでは何もしない。
+      }
     } finally {
       setSaving(false);
     }
-  }, [weekday, enablePush, disablePush, showToast]);
+  }, [weekday, enablePush, disablePush, savePreference, fetchSavedWeekday, showToast]);
 
   const dirty = weekday !== savedWeekday;
 

--- a/src/components/profile/NotificationSettings.tsx
+++ b/src/components/profile/NotificationSettings.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/useToast';
 import { apiFetch } from '@/lib/api/apiClient';
@@ -166,14 +167,14 @@ export function NotificationSettings() {
   const dirty = weekday !== savedWeekday;
 
   return (
-    <section className="bg-white border border-gray-200 rounded-lg p-6" aria-labelledby="notification-settings-title">
-      <h2 id="notification-settings-title" className="text-lg font-semibold text-gray-900">
-        通知設定
-      </h2>
-      <p className="mt-1 text-sm text-gray-600">
-        毎週、選択した曜日の朝 11:00（日本時間）に振り返りのリマインダーをお送りします。
-      </p>
-
+    <Card>
+      <CardHeader>
+        <CardTitle>通知設定</CardTitle>
+        <CardDescription>
+          毎週、選択した曜日の朝 11:00（日本時間）に振り返りのリマインダーをお送りします。
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
       {/* すでにホーム画面に追加 (standalone) 済みなら案内は出さない。
           iOS はインストール必須なので amber で強調、それ以外は任意なので gray で案内。 */}
       {mounted && !isInstalled && (
@@ -248,6 +249,7 @@ export function NotificationSettings() {
           </div>
         </div>
       )}
-    </section>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/components/profile/NotificationSettings.tsx
+++ b/src/components/profile/NotificationSettings.tsx
@@ -10,6 +10,7 @@ import {
   subscribeToPush,
   unsubscribeFromPush,
 } from '@/lib/push/client';
+import { isIOSDevice, isStandaloneDisplay } from '@/lib/pwa/standalone';
 import type { NotificationPreferences } from '@/types/push';
 
 /** OFF を表す select の値 (空文字)。曜日は '0'〜'6'。 */
@@ -49,6 +50,13 @@ export function NotificationSettings() {
   const [saving, setSaving] = useState(false);
   const [weekday, setWeekday] = useState<string>(OFF_VALUE);
   const [savedWeekday, setSavedWeekday] = useState<string>(OFF_VALUE);
+  // ホーム画面に追加した PWA でないと通知を受け取れない (特に iOS)。
+  // UA/standalone 判定は SSR では走らせず、マウント後に評価する。
+  const [needsInstallForIOS, setNeedsInstallForIOS] = useState(false);
+
+  useEffect(() => {
+    setNeedsInstallForIOS(isIOSDevice() && !isStandaloneDisplay());
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -154,6 +162,21 @@ export function NotificationSettings() {
       <p className="mt-1 text-sm text-gray-600">
         毎週、選択した曜日の朝 11:00（日本時間）に振り返りのリマインダーをお送りします。
       </p>
+
+      <div className="mt-3 rounded-md bg-gray-50 border border-gray-200 p-3 text-xs text-gray-600">
+        <p className="font-medium text-gray-700">📱 プッシュ通知を受け取るには</p>
+        <p className="mt-1">
+          ReflectHub を<strong>ホーム画面に追加（インストール）</strong>したアプリから通知を受け取れます。
+          特に iPhone / iPad では、ホーム画面に追加したアプリでのみ通知が有効で、Safari のタブからは受け取れません。
+        </p>
+      </div>
+
+      {needsInstallForIOS && (
+        <div className="mt-3 rounded-md bg-amber-50 border border-amber-200 p-3 text-xs text-amber-800" role="alert">
+          お使いの端末ではまだホーム画面に追加されていないようです。
+          共有メニューから「ホーム画面に追加」でインストールしてから通知を有効にしてください。
+        </div>
+      )}
 
       {loading ? (
         <p className="mt-4 text-sm text-gray-500">読み込み中...</p>

--- a/src/components/profile/NotificationSettings.tsx
+++ b/src/components/profile/NotificationSettings.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/hooks/useToast';
+import { apiFetch } from '@/lib/api/apiClient';
+import {
+  isPushSupported,
+  requestPushPermission,
+  subscribeToPush,
+  unsubscribeFromPush,
+} from '@/lib/push/client';
+import type { NotificationPreferences } from '@/types/push';
+
+/** OFF を表す select の値 (空文字)。曜日は '0'〜'6'。 */
+const OFF_VALUE = '';
+
+const WEEKDAY_OPTIONS: { value: string; label: string }[] = [
+  { value: OFF_VALUE, label: '通知しない (OFF)' },
+  { value: '0', label: '日曜日' },
+  { value: '1', label: '月曜日' },
+  { value: '2', label: '火曜日' },
+  { value: '3', label: '水曜日' },
+  { value: '4', label: '木曜日' },
+  { value: '5', label: '金曜日' },
+  { value: '6', label: '土曜日' },
+];
+
+function weekdayToValue(weekday: number | null | undefined): string {
+  if (weekday === null || weekday === undefined) return OFF_VALUE;
+  return String(weekday);
+}
+
+/**
+ * プロフィールページの通知設定セクション。
+ *
+ * - GET /api/preferences で現在の配信曜日を取得
+ * - 曜日 Select を 1 つ表示 (OFF / 日〜土)
+ * - 配信時刻は JST 11:00 固定 (cron 側で制御)
+ * - 保存時:
+ *   - OFF 以外を選択 → Push 購読を確実化して /api/push/subscribe に登録
+ *   - OFF を選択 → ブラウザの購読を解除して /api/push/unsubscribe に通知
+ *   - いずれも PUT /api/preferences で reminder_weekday を永続化
+ */
+export function NotificationSettings() {
+  const { showToast } = useToast();
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [weekday, setWeekday] = useState<string>(OFF_VALUE);
+  const [savedWeekday, setSavedWeekday] = useState<string>(OFF_VALUE);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await apiFetch('/api/preferences');
+        if (!res.ok) throw new Error('通知設定の取得に失敗しました。');
+        const data = (await res.json()) as {
+          preferences?: { notification_preferences?: NotificationPreferences };
+        };
+        if (cancelled) return;
+        const value = weekdayToValue(data.preferences?.notification_preferences?.reminder_weekday);
+        setWeekday(value);
+        setSavedWeekday(value);
+      } catch (err) {
+        if (cancelled) return;
+        setLoadError(err instanceof Error ? err.message : '通知設定の取得に失敗しました。');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const enablePush = useCallback(async (): Promise<boolean> => {
+    if (!isPushSupported()) {
+      showToast('このブラウザはプッシュ通知に対応していません。', 'error');
+      return false;
+    }
+    const vapidPublicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY ?? '';
+    if (!vapidPublicKey) {
+      showToast('プッシュ通知の設定が完了していません。', 'error');
+      return false;
+    }
+    const permission = await requestPushPermission();
+    if (permission !== 'granted') {
+      showToast('通知の許可が得られませんでした。', 'warning');
+      return false;
+    }
+    const subscription = await subscribeToPush(vapidPublicKey);
+    const res = await apiFetch('/api/push/subscribe', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(subscription),
+    });
+    if (!res.ok) {
+      const body = (await res.json().catch(() => ({}))) as { error?: string };
+      throw new Error(body.error || 'プッシュ通知の登録に失敗しました。');
+    }
+    return true;
+  }, [showToast]);
+
+  const disablePush = useCallback(async (): Promise<void> => {
+    const endpoint = await unsubscribeFromPush();
+    if (!endpoint) return;
+    await apiFetch('/api/push/unsubscribe', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ endpoint }),
+    });
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    try {
+      const reminderWeekday = weekday === OFF_VALUE ? null : Number(weekday);
+
+      if (reminderWeekday !== null) {
+        const ok = await enablePush();
+        if (!ok) return;
+      } else {
+        await disablePush();
+      }
+
+      const res = await apiFetch('/api/preferences', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ notification_preferences: { reminder_weekday: reminderWeekday } }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error || '通知設定の保存に失敗しました。');
+      }
+
+      setSavedWeekday(weekday);
+      showToast('通知設定を保存しました。', 'success');
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : '通知設定の保存に失敗しました。', 'error');
+    } finally {
+      setSaving(false);
+    }
+  }, [weekday, enablePush, disablePush, showToast]);
+
+  const dirty = weekday !== savedWeekday;
+
+  return (
+    <section className="bg-white border border-gray-200 rounded-lg p-6" aria-labelledby="notification-settings-title">
+      <h2 id="notification-settings-title" className="text-lg font-semibold text-gray-900">
+        通知設定
+      </h2>
+      <p className="mt-1 text-sm text-gray-600">
+        毎週、選択した曜日の朝 11:00（日本時間）に振り返りのリマインダーをお送りします。
+      </p>
+
+      {loading ? (
+        <p className="mt-4 text-sm text-gray-500">読み込み中...</p>
+      ) : loadError ? (
+        <p className="mt-4 text-sm text-red-600">{loadError}</p>
+      ) : (
+        <div className="mt-4 space-y-4">
+          <div className="space-y-1">
+            <label htmlFor="reminder-weekday" className="block text-sm font-medium text-gray-700">
+              通知する曜日
+            </label>
+            <select
+              id="reminder-weekday"
+              value={weekday}
+              disabled={saving}
+              onChange={(e) => setWeekday(e.target.value)}
+              className="block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {WEEKDAY_OPTIONS.map((opt) => (
+                <option key={opt.value || 'off'} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex justify-end">
+            <Button size="sm" onClick={handleSave} disabled={!dirty || saving}>
+              {saving ? '保存中...' : '保存'}
+            </Button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/hooks/useInstallPrompt.ts
+++ b/src/hooks/useInstallPrompt.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
+import { isIOSDevice, isStandaloneDisplay } from '@/lib/pwa/standalone';
 
 /**
  * Chrome / Edge が発火する beforeinstallprompt の型定義。
@@ -17,33 +18,6 @@ export interface BeforeInstallPromptEvent extends Event {
 
 const DISMISS_KEY = 'reflecthub:install-prompt:dismissed-at';
 const DISMISS_COOLDOWN_MS = 1000 * 60 * 60 * 24 * 14; // 14 日
-
-function isStandalone(): boolean {
-  if (typeof window === 'undefined') return false;
-  if (window.matchMedia?.('(display-mode: standalone)').matches) return true;
-  // iOS Safari の独自フラグ。
-  const navAny = window.navigator as Navigator & { standalone?: boolean };
-  return navAny.standalone === true;
-}
-
-/**
- * iOS デバイス上で動作しているかを判定する。
- *
- * iOS の Safari/Chrome/Firefox はいずれも WebKit ベースで `beforeinstallprompt`
- * を発火しない。代わりにユーザーが手動で「共有 → ホーム画面に追加」する必要が
- * あるので、その案内 UI を出すために iOS かどうかだけを見ればよい。
- *
- * iPadOS 13+ は UA が "Macintosh" を含むので、`maxTouchPoints` でタッチデバイス
- * かを併せて判定する。
- */
-function isIOSDevice(): boolean {
-  if (typeof window === 'undefined') return false;
-  const ua = window.navigator.userAgent;
-  if (/iPad|iPhone|iPod/.test(ua)) return true;
-  const isMacLike = /Macintosh/.test(ua);
-  const touchPoints = window.navigator.maxTouchPoints ?? 0;
-  return isMacLike && touchPoints > 1;
-}
 
 function readDismissedAt(): number | null {
   if (typeof window === 'undefined') return null;
@@ -85,7 +59,7 @@ export interface UseInstallPromptResult {
 export function useInstallPrompt(): UseInstallPromptResult {
   const [deferredPrompt, setDeferredPrompt] =
     useState<BeforeInstallPromptEvent | null>(null);
-  const [installed, setInstalled] = useState<boolean>(() => isStandalone());
+  const [installed, setInstalled] = useState<boolean>(() => isStandaloneDisplay());
   const [isPrompting, setIsPrompting] = useState(false);
   const [outcome, setOutcome] = useState<'accepted' | 'dismissed' | null>(null);
   const [dismissedAt, setDismissedAt] = useState<number | null>(() =>
@@ -149,7 +123,7 @@ export function useInstallPrompt(): UseInstallPromptResult {
 
     // display-mode の変更 (PWA で起動など) を検知。
     const mql = window.matchMedia?.('(display-mode: standalone)');
-    const onModeChange = () => setInstalled(isStandalone());
+    const onModeChange = () => setInstalled(isStandaloneDisplay());
     mql?.addEventListener?.('change', onModeChange);
 
     return () => {

--- a/src/lib/push/validation.test.ts
+++ b/src/lib/push/validation.test.ts
@@ -6,41 +6,28 @@ describe('validateNotificationPreferences', () => {
     it('rejects unknown keys', () => {
       expect(validateNotificationPreferences({ unknown: true })).toMatch(/不明なキー/);
     });
-  });
 
-  describe('boolean fields', () => {
-    it.each(['daily_reminder', 'weekly_summary', 'achievement_alerts'] as const)(
-      'rejects non-boolean %s',
-      (key) => {
-        expect(validateNotificationPreferences({ [key]: 'true' })).toMatch(new RegExp(key));
-      },
-    );
-
-    it('accepts valid boolean values', () => {
-      expect(
-        validateNotificationPreferences({
-          daily_reminder: true,
-          weekly_summary: false,
-          achievement_alerts: true,
-        }),
-      ).toBeNull();
+    it('rejects legacy keys that are no longer supported', () => {
+      expect(validateNotificationPreferences({ daily_reminder: true })).toMatch(/不明なキー/);
+      expect(validateNotificationPreferences({ reminder_time: '20:00' })).toMatch(/不明なキー/);
     });
   });
 
-  describe('reminder_time', () => {
-    it.each(['00:00', '09:30', '12:00', '23:59', '20:00'])('accepts valid time %s', (t) => {
-      expect(validateNotificationPreferences({ reminder_time: t })).toBeNull();
+  describe('reminder_weekday', () => {
+    it.each([0, 1, 2, 3, 4, 5, 6])('accepts valid weekday %i', (d) => {
+      expect(validateNotificationPreferences({ reminder_weekday: d })).toBeNull();
     });
 
-    it.each(['24:00', '25:30', '99:99', '12:60', '12:99', '1:00', '12:0', 'ab:cd', ''])(
-      'rejects invalid time %s',
-      (t) => {
-        expect(validateNotificationPreferences({ reminder_time: t })).toMatch(/reminder_time/);
-      },
-    );
+    it('accepts null (OFF)', () => {
+      expect(validateNotificationPreferences({ reminder_weekday: null })).toBeNull();
+    });
 
-    it('rejects non-string reminder_time', () => {
-      expect(validateNotificationPreferences({ reminder_time: 2000 })).toMatch(/reminder_time/);
+    it.each([7, -1, 1.5])('rejects out-of-range / non-integer %s', (d) => {
+      expect(validateNotificationPreferences({ reminder_weekday: d })).toMatch(/reminder_weekday/);
+    });
+
+    it('rejects non-number reminder_weekday', () => {
+      expect(validateNotificationPreferences({ reminder_weekday: '1' })).toMatch(/reminder_weekday/);
     });
   });
 

--- a/src/lib/push/validation.ts
+++ b/src/lib/push/validation.ts
@@ -1,9 +1,4 @@
-const VALID_NOTIFICATION_KEYS = new Set([
-  'daily_reminder',
-  'reminder_time',
-  'weekly_summary',
-  'achievement_alerts',
-]);
+const VALID_NOTIFICATION_KEYS = new Set(['reminder_weekday']);
 
 /**
  * notification_preferences ペイロードのキーと型を検証する。
@@ -17,19 +12,10 @@ export function validateNotificationPreferences(
       return `不明なキー "${key}" が含まれています。`;
     }
   }
-  if ('daily_reminder' in payload && typeof payload.daily_reminder !== 'boolean') {
-    return 'daily_reminder は boolean である必要があります。';
-  }
-  if ('weekly_summary' in payload && typeof payload.weekly_summary !== 'boolean') {
-    return 'weekly_summary は boolean である必要があります。';
-  }
-  if ('achievement_alerts' in payload && typeof payload.achievement_alerts !== 'boolean') {
-    return 'achievement_alerts は boolean である必要があります。';
-  }
-  if ('reminder_time' in payload) {
-    const t = payload.reminder_time;
-    if (typeof t !== 'string' || !/^(?:[01]\d|2[0-3]):[0-5]\d$/.test(t)) {
-      return 'reminder_time は HH:MM 形式 (00:00〜23:59) である必要があります。';
+  if ('reminder_weekday' in payload) {
+    const v = payload.reminder_weekday;
+    if (v !== null && (typeof v !== 'number' || !Number.isInteger(v) || v < 0 || v > 6)) {
+      return 'reminder_weekday は 0〜6 の整数または null である必要があります。';
     }
   }
   return null;

--- a/src/lib/pwa/standalone.ts
+++ b/src/lib/pwa/standalone.ts
@@ -1,0 +1,31 @@
+/**
+ * PWA のインストール状態・iOS 判定ヘルパー。
+ *
+ * Web Push は Service Worker を必要とし、特に iOS/iPadOS では
+ * 「ホーム画面に追加した PWA (standalone)」でのみ通知を受け取れる。
+ * 通知設定 UI やインストール促し UI で、この状態に応じた案内を出すために使う。
+ */
+
+/** ホーム画面に追加された PWA (standalone) として起動しているか。 */
+export function isStandaloneDisplay(): boolean {
+  if (typeof window === 'undefined') return false;
+  if (window.matchMedia?.('(display-mode: standalone)').matches) return true;
+  // iOS Safari の独自フラグ。
+  const navAny = window.navigator as Navigator & { standalone?: boolean };
+  return navAny.standalone === true;
+}
+
+/**
+ * iOS / iPadOS デバイス上で動作しているかを判定する。
+ *
+ * iPadOS 13+ は UA が "Macintosh" を含むため、`maxTouchPoints` でタッチデバイス
+ * かを併せて判定する。
+ */
+export function isIOSDevice(): boolean {
+  if (typeof window === 'undefined') return false;
+  const ua = window.navigator.userAgent;
+  if (/iPad|iPhone|iPod/.test(ua)) return true;
+  const isMacLike = /Macintosh/.test(ua);
+  const touchPoints = window.navigator.maxTouchPoints ?? 0;
+  return isMacLike && touchPoints > 1;
+}

--- a/src/lib/validation/schemas.test.ts
+++ b/src/lib/validation/schemas.test.ts
@@ -18,13 +18,28 @@ describe('PreferencesUpdateSchema', () => {
       pwa_install_dismissed: true,
       timezone: 'Asia/Tokyo',
       notification_preferences: {
-        daily_reminder: true,
-        reminder_time: '20:30',
-        weekly_summary: false,
-        achievement_alerts: true,
+        reminder_weekday: 3,
       },
     });
     expect(result.success).toBe(true);
+  });
+
+  it('accepts null reminder_weekday (OFF)', () => {
+    expect(
+      PreferencesUpdateSchema.safeParse({
+        notification_preferences: { reminder_weekday: null },
+      }).success,
+    ).toBe(true);
+  });
+
+  it('accepts every weekday value 0..6', () => {
+    for (let d = 0; d <= 6; d += 1) {
+      expect(
+        PreferencesUpdateSchema.safeParse({
+          notification_preferences: { reminder_weekday: d },
+        }).success,
+      ).toBe(true);
+    }
   });
 
   it('rejects unknown top-level keys', () => {
@@ -41,15 +56,28 @@ describe('PreferencesUpdateSchema', () => {
     ).toBe(false);
   });
 
-  it('rejects invalid reminder_time format', () => {
+  it('rejects out-of-range reminder_weekday', () => {
     expect(
       PreferencesUpdateSchema.safeParse({
-        notification_preferences: { reminder_time: '25:00' },
+        notification_preferences: { reminder_weekday: 7 },
       }).success,
     ).toBe(false);
     expect(
       PreferencesUpdateSchema.safeParse({
-        notification_preferences: { reminder_time: '9:00' },
+        notification_preferences: { reminder_weekday: -1 },
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects non-integer reminder_weekday', () => {
+    expect(
+      PreferencesUpdateSchema.safeParse({
+        notification_preferences: { reminder_weekday: 1.5 },
+      }).success,
+    ).toBe(false);
+    expect(
+      PreferencesUpdateSchema.safeParse({
+        notification_preferences: { reminder_weekday: '1' },
       }).success,
     ).toBe(false);
   });

--- a/src/lib/validation/schemas.ts
+++ b/src/lib/validation/schemas.ts
@@ -12,8 +12,6 @@ const trimmedString = (min: number, max: number) =>
       message: `${min}〜${max} 文字で入力してください。`,
     });
 
-const HHMM_PATTERN = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
-
 const BASE64URL_PATTERN = /^[A-Za-z0-9\-_]+=*$/;
 
 // ───────────────────────────────────────────────────────────────────
@@ -22,14 +20,13 @@ const BASE64URL_PATTERN = /^[A-Za-z0-9\-_]+=*$/;
 
 export const NotificationPreferencesPatchSchema = z
   .object({
-    daily_reminder: z.boolean().optional(),
-    weekly_summary: z.boolean().optional(),
-    achievement_alerts: z.boolean().optional(),
-    reminder_time: z
-      .string()
-      .regex(HHMM_PATTERN, {
-        error: 'reminder_time は HH:MM 形式 (00:00〜23:59) である必要があります。',
-      })
+    // リマインダー配信曜日。0=日曜〜6=土曜。null = OFF (配信しない)。
+    reminder_weekday: z
+      .number()
+      .int({ error: 'reminder_weekday は整数である必要があります。' })
+      .min(0, { error: 'reminder_weekday は 0〜6 である必要があります。' })
+      .max(6, { error: 'reminder_weekday は 0〜6 である必要があります。' })
+      .nullable()
       .optional(),
   })
   .strict();

--- a/src/services/preferencesService.test.ts
+++ b/src/services/preferencesService.test.ts
@@ -18,10 +18,7 @@ const mockPreferences = {
   pwa_install_dismissed: false,
   timezone: 'Asia/Tokyo',
   notification_preferences: {
-    daily_reminder: false,
-    reminder_time: '20:00',
-    weekly_summary: false,
-    achievement_alerts: true,
+    reminder_weekday: null,
   },
   created_at: '2026-04-19T00:00:00Z',
   updated_at: '2026-04-19T00:00:00Z',
@@ -128,7 +125,7 @@ describe('preferencesService', () => {
         ...mockPreferences,
         notification_preferences: {
           ...mockPreferences.notification_preferences,
-          daily_reminder: true,
+          reminder_weekday: 1,
         },
       };
       const singleFn = vi.fn().mockResolvedValue({ data: updatedPreferences, error: null });
@@ -145,11 +142,10 @@ describe('preferencesService', () => {
         .mockReturnValueOnce(updateChain as any); // update call
 
       const result = await preferencesService.updatePreferences(USER_ID, {
-        notification_preferences: { daily_reminder: true },
+        notification_preferences: { reminder_weekday: 1 },
       });
 
-      expect(result.notification_preferences.daily_reminder).toBe(true);
-      expect(result.notification_preferences.achievement_alerts).toBe(true);
+      expect(result.notification_preferences.reminder_weekday).toBe(1);
     });
 
     it('throws AUTH_ERROR when not authenticated', async () => {

--- a/src/services/preferencesService.ts
+++ b/src/services/preferencesService.ts
@@ -6,10 +6,7 @@ import type {
 } from '@/types/push';
 
 const DEFAULT_NOTIFICATION_PREFERENCES: NotificationPreferences = {
-  daily_reminder: false,
-  reminder_time: '20:00',
-  weekly_summary: false,
-  achievement_alerts: true,
+  reminder_weekday: null,
 };
 
 export const preferencesService = {

--- a/src/services/reminderService.test.ts
+++ b/src/services/reminderService.test.ts
@@ -1,62 +1,39 @@
 import { describe, it, expect } from 'vitest';
 import {
   buildReminderPayload,
-  getLocalHHMM,
+  getLocalWeekday,
   isAlreadyNotifiedToday,
-  parseHHMM,
-  shouldFireReminder,
 } from './reminderService';
 
 describe('reminderService', () => {
-  describe('parseHHMM', () => {
-    it('parses valid times', () => {
-      expect(parseHHMM('00:00')).toBe(0);
-      expect(parseHHMM('01:30')).toBe(90);
-      expect(parseHHMM('23:59')).toBe(23 * 60 + 59);
+  describe('getLocalWeekday', () => {
+    it('returns the weekday number (0=Sun..6=Sat) for a known date', () => {
+      // 2026-05-07 は木曜日 (Thursday = 4)
+      const thursdayNoonUtc = new Date(Date.UTC(2026, 4, 7, 12, 0, 0));
+      expect(getLocalWeekday(thursdayNoonUtc, 'UTC')).toBe(4);
+      // JST 21:00 でも同日 (木曜)
+      expect(getLocalWeekday(thursdayNoonUtc, 'Asia/Tokyo')).toBe(4);
     });
 
-    it('rejects invalid times', () => {
-      expect(parseHHMM('24:00')).toBeNull();
-      expect(parseHHMM('12:60')).toBeNull();
-      expect(parseHHMM('1:30')).toBeNull();
-      expect(parseHHMM('abc')).toBeNull();
-      expect(parseHHMM('')).toBeNull();
-    });
-  });
-
-  describe('shouldFireReminder', () => {
-    it('fires when within tolerance', () => {
-      expect(shouldFireReminder('20:00', '20:00', 5)).toBe(true);
-      expect(shouldFireReminder('20:03', '20:00', 5)).toBe(true);
-      expect(shouldFireReminder('19:57', '20:00', 5)).toBe(true);
+    it('respects timezone across the day boundary', () => {
+      // 2026-05-07T15:00Z は UTC では木曜(4)、Asia/Tokyo では 2026-05-08 00:00 = 金曜(5)
+      const d = new Date(Date.UTC(2026, 4, 7, 15, 0, 0));
+      expect(getLocalWeekday(d, 'UTC')).toBe(4);
+      expect(getLocalWeekday(d, 'Asia/Tokyo')).toBe(5);
     });
 
-    it('does not fire when outside tolerance', () => {
-      expect(shouldFireReminder('20:06', '20:00', 5)).toBe(false);
-      expect(shouldFireReminder('19:54', '20:00', 5)).toBe(false);
+    it('covers Sunday and Saturday', () => {
+      // 2026-05-03 は日曜日 (0)
+      const sunday = new Date(Date.UTC(2026, 4, 3, 12, 0, 0));
+      expect(getLocalWeekday(sunday, 'UTC')).toBe(0);
+      // 2026-05-09 は土曜日 (6)
+      const saturday = new Date(Date.UTC(2026, 4, 9, 12, 0, 0));
+      expect(getLocalWeekday(saturday, 'UTC')).toBe(6);
     });
 
-    it('handles wrap-around midnight', () => {
-      expect(shouldFireReminder('00:02', '23:59', 5)).toBe(true);
-      expect(shouldFireReminder('23:57', '00:01', 5)).toBe(true);
-    });
-
-    it('returns false for invalid input', () => {
-      expect(shouldFireReminder('xx:yy', '20:00', 5)).toBe(false);
-      expect(shouldFireReminder('20:00', 'bad', 5)).toBe(false);
-    });
-  });
-
-  describe('getLocalHHMM', () => {
-    it('returns HH:MM for a known timezone', () => {
-      const utcNoon = new Date(Date.UTC(2026, 0, 1, 12, 0, 0));
-      expect(getLocalHHMM(utcNoon, 'UTC')).toBe('12:00');
-      expect(getLocalHHMM(utcNoon, 'Asia/Tokyo')).toBe('21:00');
-    });
-
-    it('falls back to UTC for invalid timezone', () => {
-      const d = new Date(Date.UTC(2026, 0, 1, 5, 30, 0));
-      expect(getLocalHHMM(d, 'Not/AZone')).toBe('05:30');
+    it('falls back to UTC weekday for an invalid timezone', () => {
+      const d = new Date(Date.UTC(2026, 4, 7, 12, 0, 0));
+      expect(getLocalWeekday(d, 'Not/AZone')).toBe(d.getUTCDay());
     });
   });
 

--- a/src/services/reminderService.ts
+++ b/src/services/reminderService.ts
@@ -2,18 +2,20 @@ import { createServiceRoleClient } from '@/lib/supabase/server';
 import type { NotificationPreferences, PushSubscription } from '@/types/push';
 
 /**
- * 日次リマインダーのスケジューリング・配信対象決定ロジック。
+ * 週次リマインダーのスケジューリング・配信対象決定ロジック。
  *
- * Vercel Cron 等から呼び出されるバッチ処理ヘルパー。
- * - ユーザーごとのタイムゾーンに基づき "現在ローカル時刻" を計算
- * - 設定された reminder_time と一致するユーザーを抽出
+ * Vercel Cron から JST 11:00 (= 02:00 UTC) に 1 日 1 回呼び出される前提。
+ * - ユーザーが設定した配信曜日 (reminder_weekday) と、ローカルタイムゾーンでの
+ *   "今日の曜日" が一致するユーザーを抽出
  * - 該当ユーザーの有効な push_subscriptions を取得
+ * - 同日中の重複通知は last_notified_at で防止
  */
 
 export interface ReminderTarget {
   userId: string;
   timezone: string;
-  reminderTime: string;
+  /** 0=日曜〜6=土曜 */
+  reminderWeekday: number;
   /** ISO timestamp。未通知なら null */
   lastNotifiedAt: string | null;
   subscriptions: PushSubscription[];
@@ -37,48 +39,30 @@ export function buildReminderPayload(overrides: Partial<ReminderPayload> = {}): 
   return { ...DEFAULT_PAYLOAD, ...overrides };
 }
 
+const WEEKDAY_MAP: Record<string, number> = {
+  Sun: 0,
+  Mon: 1,
+  Tue: 2,
+  Wed: 3,
+  Thu: 4,
+  Fri: 5,
+  Sat: 6,
+};
+
 /**
- * 指定 timezone での現在 HH:MM を返す。タイムゾーンが不正な場合は UTC にフォールバック。
+ * 指定 timezone での現在の曜日 (0=日曜〜6=土曜) を返す。
+ * タイムゾーンが不正な場合は UTC の曜日にフォールバックする。
  */
-export function getLocalHHMM(now: Date, timezone: string): string {
+export function getLocalWeekday(now: Date, timezone: string): number {
   try {
-    const formatter = new Intl.DateTimeFormat('en-GB', {
+    const short = new Intl.DateTimeFormat('en-US', {
       timeZone: timezone,
-      hour12: false,
-      hour: '2-digit',
-      minute: '2-digit',
-    });
-    return formatter.format(now);
+      weekday: 'short',
+    }).format(now);
+    return WEEKDAY_MAP[short] ?? now.getUTCDay();
   } catch {
-    const hh = String(now.getUTCHours()).padStart(2, '0');
-    const mm = String(now.getUTCMinutes()).padStart(2, '0');
-    return `${hh}:${mm}`;
+    return now.getUTCDay();
   }
-}
-
-/**
- * "HH:MM" を分単位の数値へ。不正値は null。
- */
-export function parseHHMM(value: string): number | null {
-  if (!/^(?:[01]\d|2[0-3]):[0-5]\d$/.test(value)) return null;
-  const [h, m] = value.split(':').map(Number);
-  return h * 60 + m;
-}
-
-/**
- * リマインダー時刻と現在時刻の差が許容範囲内なら true。
- * Cron が ±tolerance 分間隔で動く前提で使う。
- */
-export function shouldFireReminder(
-  nowHHMM: string,
-  reminderTime: string,
-  toleranceMinutes = 5,
-): boolean {
-  const nowMin = parseHHMM(nowHHMM);
-  const targetMin = parseHHMM(reminderTime);
-  if (nowMin === null || targetMin === null) return false;
-  const diff = Math.abs(nowMin - targetMin);
-  return diff <= toleranceMinutes || diff >= 1440 - toleranceMinutes;
 }
 
 interface UserPreferenceRow {
@@ -116,7 +100,7 @@ export function isAlreadyNotifiedToday(
 
 export interface ReminderTargetsResult {
   targets: ReminderTarget[];
-  /** リマインダー時刻にマッチしたが、同日中に通知済みのためスキップしたユーザー数 */
+  /** 配信曜日にマッチしたが、同日中に通知済みのためスキップしたユーザー数 */
   skippedAlreadyNotified: number;
 }
 
@@ -124,10 +108,11 @@ export interface ReminderTargetsResult {
  * 配信対象のユーザーと subscription を返す。
  * RLS をバイパスする必要があるため service-role クライアントを使う。
  * Cron など信頼できるサーバー文脈からのみ呼び出すこと。
+ *
+ * timezone フィールドは残しているが、当面は全ユーザー JST (Asia/Tokyo) 前提で動作する。
  */
 export async function getReminderTargets(
   now: Date = new Date(),
-  toleranceMinutes = 5,
 ): Promise<ReminderTargetsResult> {
   const supabase = createServiceRoleClient();
 
@@ -143,12 +128,10 @@ export async function getReminderTargets(
 
   let skippedAlreadyNotified = 0;
   const candidates = (prefs as UserPreferenceRow[]).filter((row) => {
-    const np = row.notification_preferences;
-    if (!np || !np.daily_reminder) return false;
-    const reminderTime = np.reminder_time ?? '20:00';
-    const tz = row.timezone || 'UTC';
-    const localNow = getLocalHHMM(now, tz);
-    if (!shouldFireReminder(localNow, reminderTime, toleranceMinutes)) return false;
+    const weekday = row.notification_preferences?.reminder_weekday;
+    if (weekday === null || weekday === undefined) return false;
+    const tz = row.timezone || 'Asia/Tokyo';
+    if (getLocalWeekday(now, tz) !== weekday) return false;
     if (isAlreadyNotifiedToday(now, tz, row.last_notified_at)) {
       skippedAlreadyNotified += 1;
       return false;
@@ -181,8 +164,8 @@ export async function getReminderTargets(
   const targets = candidates
     .map((row) => ({
       userId: row.user_id,
-      timezone: row.timezone || 'UTC',
-      reminderTime: row.notification_preferences?.reminder_time ?? '20:00',
+      timezone: row.timezone || 'Asia/Tokyo',
+      reminderWeekday: row.notification_preferences!.reminder_weekday as number,
       lastNotifiedAt: row.last_notified_at,
       subscriptions: byUser.get(row.user_id) ?? [],
     }))
@@ -207,7 +190,7 @@ export async function markUserNotified(userId: string, now: Date = new Date()): 
 }
 
 /**
- * Push エンドポイントが失効した subscription (404/410/401) を非アクティブ化する。
+ * Push エンドポイントが失効した subscription (404/410) を非アクティブ化する。
  */
 export async function deactivateSubscriptions(subscriptionIds: string[]): Promise<void> {
   if (subscriptionIds.length === 0) return;

--- a/src/services/reminderService.ts
+++ b/src/services/reminderService.ts
@@ -39,6 +39,13 @@ export function buildReminderPayload(overrides: Partial<ReminderPayload> = {}): 
   return { ...DEFAULT_PAYLOAD, ...overrides };
 }
 
+/**
+ * リマインダー配信は JST 11:00 固定。曜日判定・同日判定はすべてこの固定の
+ * タイムゾーンで行う。user_preferences.timezone はユーザーが変更でき得るため、
+ * 配信曜日の判定には使わない (非 JST の値が入ると曜日がずれるため)。
+ */
+const REMINDER_TIMEZONE = 'Asia/Tokyo';
+
 const WEEKDAY_MAP: Record<string, number> = {
   Sun: 0,
   Mon: 1,
@@ -130,9 +137,9 @@ export async function getReminderTargets(
   const candidates = (prefs as UserPreferenceRow[]).filter((row) => {
     const weekday = row.notification_preferences?.reminder_weekday;
     if (weekday === null || weekday === undefined) return false;
-    const tz = row.timezone || 'Asia/Tokyo';
-    if (getLocalWeekday(now, tz) !== weekday) return false;
-    if (isAlreadyNotifiedToday(now, tz, row.last_notified_at)) {
+    // 配信は JST 固定。保存済み timezone ではなく常に JST で曜日・同日を判定する。
+    if (getLocalWeekday(now, REMINDER_TIMEZONE) !== weekday) return false;
+    if (isAlreadyNotifiedToday(now, REMINDER_TIMEZONE, row.last_notified_at)) {
       skippedAlreadyNotified += 1;
       return false;
     }
@@ -164,7 +171,7 @@ export async function getReminderTargets(
   const targets = candidates
     .map((row) => ({
       userId: row.user_id,
-      timezone: row.timezone || 'Asia/Tokyo',
+      timezone: REMINDER_TIMEZONE,
       reminderWeekday: row.notification_preferences!.reminder_weekday as number,
       lastNotifiedAt: row.last_notified_at,
       subscriptions: byUser.get(row.user_id) ?? [],

--- a/src/types/push.ts
+++ b/src/types/push.ts
@@ -20,10 +20,12 @@ export interface CreatePushSubscriptionRequest {
 }
 
 export interface NotificationPreferences {
-  daily_reminder: boolean;
-  reminder_time?: string; // HH:MM format
-  weekly_summary: boolean;
-  achievement_alerts: boolean;
+  /**
+   * リマインダーを配信する曜日。0=日曜〜6=土曜。
+   * null の場合は配信しない (OFF)。
+   * 配信時刻は JST 11:00 固定 (cron 側で制御)。
+   */
+  reminder_weekday: number | null;
 }
 
 export interface UserPreferences {

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/cron/daily-reminder",
-      "schedule": "0 11 * * *"
+      "schedule": "0 2 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Closes #90

PR #98 (Web Push 実送信) のマージを受け、通知設定を「**曜日を 1 つだけ選択**」するシンプルな設計に作り直した。配信時刻は **JST 11:00 固定**（Vercel Cron）。

> 注: 本 PR は旧設計（毎日/週1 + 時刻指定）から全面的に書き換え (force push) しています。

### 設計

- 配信時刻: **JST 11:00 固定**（cron `0 2 * * *` UTC = JST 11:00）
- ユーザー設定: 配信曜日を **1 つだけ**選択（OFF / 日 / 月 / … / 土）
- DB: `notification_preferences.reminder_weekday: number | null`（0=日〜6=土、null = OFF）
- 旧 `daily_reminder` / `weekly_summary` / `reminder_time` / `achievement_alerts` は廃止
- `timezone` フィールドは残すが当面 JST 固定動作

### 変更内容

- **型**: `NotificationPreferences` を `{ reminder_weekday: number | null }` に簡素化
- **`reminderService`**: 曜日フィルタへ変更。`getLocalHHMM` / `parseHHMM` / `shouldFireReminder` を削除し、`getLocalWeekday` を追加。`getReminderTargets` は「今日の曜日 == reminder_weekday」のユーザーを抽出
- **`preferencesService` / `/api/preferences`**: デフォルト値を新モデルに
- **バリデーション**: `schemas.ts`（zod）と `lib/push/validation.ts` を `reminder_weekday`（0〜6 の整数 or null）検証に変更
- **`NotificationSettings` コンポーネント**（新規）: 曜日 Select 1 個。OFF 以外を選択して保存すると Push 購読 → `/api/push/subscribe`、OFF にすると購読解除 → `/api/push/unsubscribe`。いずれも `apiFetch`（CSRF 自動付与）で `/api/preferences` に PUT。プロフィールページに組み込み
- **`vercel.json`**: cron を `0 2 * * *`（JST 11:00）に変更
- **DB**: `user_preferences.notification_preferences` のデフォルトを更新し、既存行を移行する `database/notification-preferences-weekday.sql` を追加（既存行は OFF にリセット）
- **テスト**: 全関連テストを新モデルに書き換え、`NotificationSettings.test.tsx` を新設

### PWA / 通知の前提（重要）

Web Push は Service Worker を必要とし、特に **iOS / iPadOS ではホーム画面に追加した PWA（standalone）でのみ**通知を受け取れます（Safari のタブでは不可）。これを UI で案内し、未インストール時はインストール導線を提示します。

- **インストール済み（standalone）なら案内・警告を一切表示しない**（Select のみ表示）
- 未インストール時のみインストール案内を表示:
  - Chromium 系（`beforeinstallprompt` あり）: 「**アプリをインストール**」ボタンで `promptInstall` を起動。承諾後は `appinstalled` を検知して案内が自動的に消える
  - iOS など prompt が来ない環境: 「共有 → ホーム画面に追加」の手順を表示
- インストール状態 / UA 判定はマウント後に評価し、hydration mismatch を回避
- standalone / iOS 判定を `src/lib/pwa/standalone.ts` に切り出し、`useInstallPrompt` の重複ロジックを置き換え（DRY 化）。`NotificationSettings` は `useInstallPrompt` を利用

#### 表示ロジック

| 状態 | 表示 |
|---|---|
| インストール済み (standalone) | 案内なし。曜日 Select のみ |
| 未インストール・Chromium | 「アプリをインストール」ボタン |
| 未インストール・iOS | ホーム画面追加の手順 |
| 未インストール・その他 | テキスト案内のみ |

### テスト / 確認

- `pnpm test:run` … 関連テスト（reminderService / preferencesService / preferences route / schemas / push validation / NotificationSettings / useInstallPrompt / profile page）すべてグリーン
- `next build` … 成功（`/profile` を含む全ルートがビルド可能）
- 既存の失敗テスト（`authStore.test.ts` の timeout メッセージ）と lint の `as any` 警告は `main` 由来の既存事象で、本 PR では未変更

### マイグレーション手順（マージ後）

Supabase Studio で `database/notification-preferences-weekday.sql` を実行（既存ユーザーの通知設定は一旦 OFF にリセットされ、再設定が必要）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)