### PR TITLE
chore(db): public スキーマへの明示的 GRANT を追加（Supabase Data API 公開ポリシー変更対応）

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -1,5 +1,35 @@
 # データベースマイグレーション
 
+## Data API 公開ポリシー（必読）
+
+2026-05-30 以降の新規 Supabase プロジェクトでは、`public` スキーマのテーブルは
+PostgREST / GraphQL / supabase-js から**自動公開されなくなる**。
+ReflectHub のような既存プロジェクトも 2026-10-30 までに同じ挙動になる予定。
+
+**新しいテーブルを作る migration を追加するときは、必ず明示的な `GRANT` を併記すること。**
+RLS ポリシーがあってもロールにベース権限が無ければ到達できない。
+
+書き方の例:
+
+```sql
+-- ブラウザクライアントから直接 CRUD するテーブル
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.<table> TO authenticated;
+GRANT ALL ON public.<table> TO service_role;
+
+-- 書き込みを RPC 経由に閉じたいテーブル
+GRANT SELECT ON public.<table> TO authenticated;
+
+-- 未認証ユーザーからも書き込みを受け付けるテーブル（例: error_logs）
+GRANT INSERT ON public.<table> TO anon;
+```
+
+既存テーブルへ一括で同等の権限を付与したい場合は
+[`data-api-grants.sql`](./data-api-grants.sql) を流す（ベキ等）。
+
+参考: https://github.com/orgs/supabase/discussions/45329
+
+---
+
 ## Phase 2: フレームワーク拡張（2個 → 7個）
 
 ### 実行手順（2段階）

--- a/database/data-api-grants.sql
+++ b/database/data-api-grants.sql
@@ -1,0 +1,72 @@
+-- =====================================================================
+-- Data API ロールへの権限付与（ベースライン）
+-- =====================================================================
+-- 2026-05-30 以降の新規 Supabase プロジェクトでは public スキーマのテーブルが
+-- PostgREST / GraphQL / supabase-js から自動アクセス可能ではなくなる。
+-- 既存プロジェクト（ReflectHub もこれ）は 2026-10-30 まで旧挙動だが、
+-- それ以降に作る新テーブルは明示的な GRANT が必要になる。
+-- 参考: https://github.com/orgs/supabase/discussions/45329
+--
+-- このファイルは「現状の public スキーマ全テーブルに対する想定 GRANT」を
+-- ベキ等にまとめたもの。新環境を立てる際や、現行プロジェクトで
+-- 期限前に明示権限付与を行いたい場合に流す。
+--
+-- 各テーブルへのアクセス経路と必要ロールはアプリ実装から逆算している:
+--   profiles            : サーバ側 API ルート（cookie auth）→ authenticated
+--   frameworks          : ブラウザ client から SELECT のみ → authenticated
+--   retrospectives      : ブラウザ client から CRUD       → authenticated
+--   push_subscriptions  : ブラウザ + reminder の service_role
+--   user_preferences    : ブラウザ + reminder の service_role
+--   error_logs          : POST は未ログインも許容 / GET は認証必須
+--   ai_summaries        : ブラウザから SELECT のみ（書込みは RPC 経由）
+--
+-- 注意: 書き込みを禁じたいテーブル（例: ai_summaries）は SELECT のみ付与。
+--       書込みは SECURITY DEFINER の RPC 関数経由に統一する設計を維持する。
+-- =====================================================================
+
+-- profiles --------------------------------------------------------------
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.profiles TO authenticated;
+GRANT ALL ON public.profiles TO service_role;
+
+-- frameworks ------------------------------------------------------------
+-- マスタデータ。ログイン後のブラウザクライアントから読むだけ。
+GRANT SELECT ON public.frameworks TO authenticated;
+GRANT ALL ON public.frameworks TO service_role;
+
+-- retrospectives --------------------------------------------------------
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.retrospectives TO authenticated;
+GRANT ALL ON public.retrospectives TO service_role;
+
+-- push_subscriptions / user_preferences ---------------------------------
+-- push-subscriptions-and-preferences.sql と重複するが、既存 DB に対する
+-- ベキ等な適用ができるよう同じ GRANT を再掲する。
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.push_subscriptions TO authenticated;
+GRANT ALL ON public.push_subscriptions TO service_role;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.user_preferences TO authenticated;
+GRANT ALL ON public.user_preferences TO service_role;
+
+-- error_logs ------------------------------------------------------------
+-- POST /api/logs/errors は未認証ユーザーからのクライアントエラーも
+-- 受け付けるため、anon にも INSERT を許可する。
+-- 読み取り（GET）は認証ユーザーのみに制限。
+GRANT INSERT ON public.error_logs TO anon;
+GRANT SELECT, INSERT ON public.error_logs TO authenticated;
+GRANT ALL ON public.error_logs TO service_role;
+
+-- ai_summaries ----------------------------------------------------------
+-- 書き込みは SECURITY DEFINER RPC 経由のみ。クライアントには SELECT だけ許可。
+GRANT SELECT ON public.ai_summaries TO authenticated;
+GRANT ALL ON public.ai_summaries TO service_role;
+
+-- =====================================================================
+-- 確認クエリ
+-- =====================================================================
+-- 付与済み権限を確認したい場合は以下を実行:
+--
+-- SELECT grantee, table_name, string_agg(privilege_type, ', ' ORDER BY privilege_type) AS privileges
+-- FROM information_schema.role_table_grants
+-- WHERE table_schema = 'public'
+--   AND grantee IN ('anon', 'authenticated', 'service_role')
+-- GROUP BY grantee, table_name
+-- ORDER BY table_name, grantee;

--- a/database/push-subscriptions-and-preferences.sql
+++ b/database/push-subscriptions-and-preferences.sql
@@ -54,6 +54,13 @@ CREATE TRIGGER push_subscriptions_updated_at
   BEFORE UPDATE ON push_subscriptions
   FOR EACH ROW EXECUTE FUNCTION update_push_subscriptions_updated_at();
 
+-- Data API ロールへの権限付与
+-- 2026-05-30 以降の新規 Supabase プロジェクトでは public スキーマが Data API に
+-- 自動公開されなくなるため、明示的に GRANT が必要。RLS だけでは到達できない。
+-- 既存プロジェクトも 2026-10-30 までに同様の挙動になる。
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.push_subscriptions TO authenticated;
+GRANT ALL ON public.push_subscriptions TO service_role;
+
 
 -- User Preferences テーブル
 CREATE TABLE IF NOT EXISTS user_preferences (
@@ -107,3 +114,7 @@ DROP TRIGGER IF EXISTS user_preferences_updated_at ON user_preferences;
 CREATE TRIGGER user_preferences_updated_at
   BEFORE UPDATE ON user_preferences
   FOR EACH ROW EXECUTE FUNCTION update_user_preferences_updated_at();
+
+-- Data API ロールへの権限付与（同上の理由）
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.user_preferences TO authenticated;
+GRANT ALL ON public.user_preferences TO service_role;


### PR DESCRIPTION
## Summary

2026-05-30 以降の新規 Supabase プロジェクトでは `public` スキーマのテーブルが Data API（PostgREST / GraphQL / supabase-js）に**自動公開されなくなる**変更が入る。既存プロジェクト（ReflectHub もこれ）も 2026-10-30 までに同じ挙動になる予定。RLS ポリシーがあってもロールにベース権限が無いと到達できないため、各テーブルに明示的な `GRANT` を付ける運用へ切り替える。

参考: https://github.com/orgs/supabase/discussions/45329

## 変更内容

- **`database/push-subscriptions-and-preferences.sql`**: `push_subscriptions` / `user_preferences` に `authenticated` / `service_role` への `GRANT` を追記
- **`database/data-api-grants.sql` (新規)**: 既存全テーブル分の権限をベキ等に集約した一括適用 SQL
  - `profiles`, `frameworks`, `retrospectives`, `push_subscriptions`, `user_preferences`, `error_logs`, `ai_summaries`
  - `error_logs` は POST が未認証も許容するため `anon` にも INSERT 付与
  - `ai_summaries` は書込みを RPC 経由に閉じる設計に合わせて SELECT のみ
- **`database/README.md`**: 新テーブル作成時に必ず GRANT を併記するルールと書き方サンプルを明文化

## アクセス経路と必要ロール（実装からの逆算）

| テーブル | 利用箇所 | ロール |
|---|---|---|
| `profiles` | サーバ API（cookie auth） | `authenticated` |
| `frameworks` | ブラウザ client から SELECT のみ | `authenticated` |
| `retrospectives` | ブラウザ client から CRUD | `authenticated` |
| `push_subscriptions` | ブラウザ + reminder の service_role | `authenticated`, `service_role` |
| `user_preferences` | ブラウザ + reminder の service_role | `authenticated`, `service_role` |
| `error_logs` | POST は未認証許容 / GET は認証必須 | `anon` (INSERT), `authenticated` |
| `ai_summaries` | ブラウザから SELECT のみ（書込は RPC） | `authenticated` (SELECT のみ) |

## 関連

- PR #85 の `database/ai-summaries.sql` にも同種の対応が必要。[該当 PR にコメント済み](https://github.com/hiiragi17/ReflectHub/pull/85#issuecomment-4553862791)。

## Test plan

- [ ] `database/data-api-grants.sql` を Supabase Studio で実行してエラーが出ないこと（ベキ等なので何度流しても OK）
- [ ] 末尾のコメントアウトされている確認クエリで `anon` / `authenticated` / `service_role` の権限が想定通りになっていること
- [ ] 適用後、既存機能（ログイン、振り返り作成・閲覧、通知設定の保存、エラーログ送信）が引き続き動作すること

---
_Generated by [Claude Code](https://claude.ai/code/session_01VF6Wn8Yf1nSgfPGVmYvdmm)_