### PR TITLE
chore(db): error_logs テーブルの migration を追加 (Phase 2.4 の書き漏れ補修)

### DIFF
--- a/database/error-logs.sql
+++ b/database/error-logs.sql
@@ -10,6 +10,8 @@
 CREATE TABLE IF NOT EXISTS error_logs (
   -- クライアント側で生成される ID (UUID 文字列)。
   -- 同一エラーの重複送信を防ぐ目的で primary key として扱う。
+  -- 重複が発生したリトライは API 側 (route.ts) で
+  -- upsert + ignoreDuplicates により 200 を返すよう吸収する。
   id TEXT PRIMARY KEY,
 
   -- 未認証ユーザーからのエラーも受け付けるため nullable。

--- a/database/error-logs.sql
+++ b/database/error-logs.sql
@@ -1,0 +1,83 @@
+-- =====================================================================
+-- Error Logs テーブル
+-- =====================================================================
+-- Phase 2.4 (issue #68) で API ルート `src/app/api/logs/errors/route.ts`
+-- が追加された際に DB migration が書き漏れていたため、本ファイルで補う。
+-- フロントエンドからの uncaught_error / unhandled_rejection 等を
+-- バッチ送信で受け取り、本テーブルに保存する。
+-- =====================================================================
+
+CREATE TABLE IF NOT EXISTS error_logs (
+  -- クライアント側で生成される ID (UUID 文字列)。
+  -- 同一エラーの重複送信を防ぐ目的で primary key として扱う。
+  id TEXT PRIMARY KEY,
+
+  -- 未認証ユーザーからのエラーも受け付けるため nullable。
+  user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+
+  -- src/types/errorTracking.ts の ErrorCategory に対応:
+  -- 'uncaught_error' | 'unhandled_rejection' | 'network' | 'offline' |
+  -- 'validation' | 'authentication' | 'authorization' | 'not_found' |
+  -- 'server' | 'unknown'
+  error_type TEXT NOT NULL,
+  message TEXT NOT NULL,
+  stack TEXT,
+  status_code INTEGER,
+
+  -- src/types/errorTracking.ts の ErrorSeverity に対応:
+  -- 'critical' | 'error' | 'warning' | 'info'
+  severity TEXT NOT NULL,
+
+  -- 追加コンテキスト (ErrorTrackingContext)。
+  page TEXT,
+  action TEXT,
+  url TEXT,
+  user_agent TEXT,
+  session_id TEXT,
+  metadata JSONB,
+
+  -- 解決状況の管理用 (route.ts GET ハンドラが返す)。
+  resolved BOOLEAN NOT NULL DEFAULT false,
+  resolved_at TIMESTAMPTZ,
+  resolved_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- GET /api/logs/errors は user_id でフィルタ + created_at DESC で並べるため、
+-- 複合インデックスを張る。pagination もこのインデックスで効く。
+CREATE INDEX IF NOT EXISTS error_logs_user_created_idx
+  ON error_logs (user_id, created_at DESC);
+
+-- 重大度別の集計用 (未使用だが将来のダッシュボード想定)。
+CREATE INDEX IF NOT EXISTS error_logs_severity_idx
+  ON error_logs (severity);
+
+-- RLS 有効化
+ALTER TABLE error_logs ENABLE ROW LEVEL SECURITY;
+
+-- 認証済みユーザーは自分のログのみ参照可能。
+DROP POLICY IF EXISTS "Users can view own error logs" ON error_logs;
+CREATE POLICY "Users can view own error logs"
+  ON error_logs FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- 認証済みユーザーは自分の user_id 付きログを INSERT 可能。
+DROP POLICY IF EXISTS "Users can insert own error logs" ON error_logs;
+CREATE POLICY "Users can insert own error logs"
+  ON error_logs FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+-- 未認証ユーザー (ログイン前のクラッシュなど) は user_id NULL でのみ INSERT 可能。
+-- これによりクライアント側のユーザー詐称を防ぐ。
+DROP POLICY IF EXISTS "Anon can insert anonymous error logs" ON error_logs;
+CREATE POLICY "Anon can insert anonymous error logs"
+  ON error_logs FOR INSERT
+  TO anon
+  WITH CHECK (user_id IS NULL);
+
+-- Data API ロールへの権限付与
+-- (2026-05-30 以降の Supabase 仕様変更対応。詳細は database/README.md)
+GRANT INSERT ON public.error_logs TO anon;
+GRANT SELECT, INSERT ON public.error_logs TO authenticated;
+GRANT ALL ON public.error_logs TO service_role;

--- a/src/app/api/logs/errors/route.test.ts
+++ b/src/app/api/logs/errors/route.test.ts
@@ -11,14 +11,14 @@ import { createClient } from '@/lib/supabase/server';
 const mockUserId = 'user-test-123';
 
 function makeSupabaseMock(overrides: Record<string, unknown> = {}) {
-  const mockInsert = vi.fn().mockResolvedValue({ error: null });
+  const mockUpsert = vi.fn().mockResolvedValue({ error: null });
   const mockSelect = vi.fn().mockReturnThis();
   const mockEq = vi.fn().mockReturnThis();
   const mockOrder = vi.fn().mockReturnThis();
   const mockRange = vi.fn().mockResolvedValue({ data: [], error: null, count: 0 });
 
   const fromMock = vi.fn().mockReturnValue({
-    insert: mockInsert,
+    upsert: mockUpsert,
     select: mockSelect,
     eq: mockEq,
     order: mockOrder,
@@ -86,10 +86,40 @@ describe('POST /api/logs/errors', () => {
     expect(data.received).toBe(1);
   });
 
+  it('uses upsert with ignoreDuplicates so retried logs do not 500', async () => {
+    const supabase = makeSupabaseMock();
+    const upsertMock = vi.fn().mockResolvedValue({ error: null });
+    supabase.from.mockReturnValue({ upsert: upsertMock });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (createClient as any).mockResolvedValue(supabase);
+
+    const logs = [
+      {
+        id: 'log-retry',
+        errorType: 'network',
+        message: 'retry',
+        context: { page: '/', url: 'http://localhost/', timestamp: Date.now() },
+        severity: 'error',
+        resolved: false,
+        createdAt: Date.now(),
+      },
+    ];
+    const req = new NextRequest('http://localhost/api/logs/errors', {
+      method: 'POST',
+      body: JSON.stringify({ logs, sessionId: 'sess_1', batchId: 'b3', sentAt: Date.now() }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(upsertMock).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ onConflict: 'id', ignoreDuplicates: true }),
+    );
+  });
+
   it('returns 500 when DB insert fails', async () => {
     const supabase = makeSupabaseMock();
     supabase.from.mockReturnValue({
-      insert: vi.fn().mockResolvedValue({ error: { message: 'DB error' } }),
+      upsert: vi.fn().mockResolvedValue({ error: { message: 'DB error' } }),
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (createClient as any).mockResolvedValue(supabase);

--- a/src/app/api/logs/errors/route.ts
+++ b/src/app/api/logs/errors/route.ts
@@ -85,7 +85,13 @@ export async function POST(request: NextRequest) {
 
     const rows = logs.map((log) => rowFromLog(log, userId, body.sessionId));
 
-    const { error } = await supabase.from('error_logs').insert(rows);
+    // `id` (クライアント生成 UUID) を PK にしているため、リトライで
+    // 同じバッチが再送されると INSERT が duplicate key で失敗する
+    // (`src/lib/errorTracking/client.ts` は !res.ok で queue.unshift して
+    //  再送する仕組み)。upsert + ignoreDuplicates で idempotent にする。
+    const { error } = await supabase
+      .from('error_logs')
+      .upsert(rows, { onConflict: 'id', ignoreDuplicates: true });
 
     if (error) {
       console.error('[ErrorLogs] DB insert failed:', error.message);


### PR DESCRIPTION
## Summary

Phase 2.4 (issue #68 / commit acd4866) で `src/app/api/logs/errors/route.ts` が追加された際、対応する `CREATE TABLE error_logs` の migration **SQL が書き漏れていた** ことが判明したため補修する。

PR #102 (`data-api-grants.sql`) を Supabase で実行したところ `ERROR: 42P01: relation "public.error_logs" does not exist` で停止し発覚。本番では POST `/api/logs/errors` が長期間 500 を返し続け、エラーログ機能が **DB レベルで動いていなかった** 可能性が高い。

## 変更内容

- **`database/error-logs.sql` (新規)**: `src/app/api/logs/errors/route.ts` と `src/types/errorTracking.ts` から逆算した CREATE TABLE + index + RLS + GRANT を完備
  - `id TEXT PRIMARY KEY` (クライアント生成 UUID。同一エラーの重複保存を防ぐため PK)
  - `user_id` nullable (未認証時のクラッシュも記録)
  - `(user_id, created_at DESC)` 複合 index で GET pagination を最適化
  - RLS:
    - 認証済みユーザー: `auth.uid() = user_id` の SELECT / INSERT のみ
    - anon ロール: `user_id IS NULL` の INSERT のみ (ユーザー詐称防止)
  - GRANT: PR #102 の `data-api-grants.sql` と整合

## 実行手順

1. 本 PR を merge
2. Supabase Console → SQL Editor で `database/error-logs.sql` を実行
3. 再度 `database/data-api-grants.sql` を流す (今回は error_logs テーブルが存在するためエラーなく完了)
4. POST `/api/logs/errors` で 500 が出ないことを確認

## 余談 (フォローアップ候補)

`data-api-grants.sql` 自体が「ベキ等」を謳いながら **存在しないテーブルに当たると停止** する設計上の脆さがある。各 GRANT を `DO $$ IF EXISTS THEN ... END $$` で囲む防御版に直す follow-up issue を別途切ると、他環境への展開時に同種事故を防げる。

## Test plan

- [ ] `database/error-logs.sql` を Supabase で実行してエラーが出ないこと
- [ ] 続けて `database/data-api-grants.sql` を再実行して通ること
- [ ] PR #102 末尾の確認クエリで `error_logs` に `anon` INSERT / `authenticated` SELECT,INSERT / `service_role` ALL が付いていること
- [ ] 適用後、Vercel ログから `relation "public.error_logs" does not exist` が消えること
- [ ] フロントエンドからエラーを発生させ、`error_logs` テーブルに行が INSERT されることを確認

https://claude.ai/code/session_01KF57dRycBn2dJJkCCDzkdP

---
_Generated by [Claude Code](https://claude.ai/code/session_01KF57dRycBn2dJJkCCDzkdP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added error logging infrastructure with secure access controls ensuring users can only view their own error data.
  * Implemented privacy-preserving error tracking supporting both authenticated and anonymous error capture.
  * Enhanced error data storage with optimized indexing for efficient error analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->