### PR TITLE
feat: 日次リマインダーを pg_cron に移行し配信時刻を JST 11:00 に精度向上

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -49,6 +49,37 @@ VAPID キーペアは `pnpm exec web-push generate-vapid-keys` で生成する
 
 ---
 
+## Phase 4: 配信時刻の精度向上 (Vercel Cron → pg_cron)
+
+`daily-reminder-pg-cron.sql` を Supabase SQL Editor で実行する。
+
+### 背景
+
+Vercel Cron は起動時刻が数十分ブレる (11:00 予定が 11:22 起動など) ため、
+ユーザーには「中途半端な時刻に通知が来る」ように見えていた。
+Supabase の `pg_cron` は分ちょうどに起動するため、**追加コストゼロ**
+(無料プランでも `pg_cron` / `pg_net` 利用可) で配信時刻を JST 11:00 に揃える。
+
+### 実行手順
+
+1. `daily-reminder-pg-cron.sql` を開き、以下 2 箇所を環境に合わせて置換する:
+   - `reminder_endpoint_url`: 本番の絶対 URL
+     (例 `https://reflecthub.app/api/cron/daily-reminder`)
+   - `cron_secret`: Vercel に設定している `CRON_SECRET` と同じ値
+2. Supabase SQL Editor に貼り付けて実行する (ベキ等・再実行可)。
+3. `select * from cron.job;` でジョブ `daily-reminder` が登録されたことを確認。
+4. 動作確認は `select * from cron.job_run_details order by start_time desc limit 10;`
+   と `select * from net._http_response order by created desc limit 10;` で行う。
+
+### 注意
+
+- このスクリプトの実行と同時に、`vercel.json` から Vercel Cron 定義を削除済み。
+  **二重スケジュールにはならない** (なお重複送信は `last_notified_at` でも防止される)。
+- `CRON_SECRET` をローテーションした場合は、本スクリプトの `cron_secret` を
+  更新して再実行すること (Vault の値が更新される)。
+
+---
+
 
 ## Phase 2: フレームワーク拡張（2個 → 7個）
 

--- a/database/daily-reminder-pg-cron.sql
+++ b/database/daily-reminder-pg-cron.sql
@@ -1,0 +1,80 @@
+-- 日次リマインダーを Supabase pg_cron で「JST 11:00 ちょうど」に配信する。
+--
+-- 背景:
+--   従来は Vercel Cron (`vercel.json` の `0 2 * * *`) から
+--   /api/cron/daily-reminder を叩いていたが、Vercel Cron は起動時刻が
+--   数十分ブレる (例: 11:00 予定が 11:22 起動) ため、ユーザーには
+--   "中途半端な時刻に通知が来る" ように見えていた。
+--
+--   pg_cron は Postgres 内部のバックグラウンドワーカーが毎分スケジュールを
+--   評価して実行するため、指定した分ちょうどに起動する。これにより
+--   追加コストゼロ (Supabase 無料プランでも pg_cron / pg_net 利用可) で
+--   配信時刻の精度を上げる。
+--
+-- このスクリプトは Supabase SQL Editor で実行する。ベキ等 (再実行可能)。
+
+-- 1) 拡張を有効化
+--    pg_cron: スケジューラ / pg_net: DB から外部 HTTP を叩く
+create extension if not exists pg_cron;
+create extension if not exists pg_net;
+
+-- 2) 秘密情報を Vault に登録する。
+--    マイグレーションに平文で書かないため、CRON_SECRET と配信エンドポイント URL は
+--    Supabase Vault に保存し、ジョブ実行時に復号して参照する。
+--
+--    下記 2 つの値は環境に合わせて置き換えてから実行すること:
+--      - reminder_endpoint_url: 本番の絶対 URL
+--          例) https://reflecthub.app/api/cron/daily-reminder
+--      - cron_secret: Vercel に設定している CRON_SECRET と同じ値
+--
+--    既に同名のシークレットがある場合は値を更新する (ベキ等)。
+do $$
+declare
+  v_url text := 'https://YOUR-DOMAIN/api/cron/daily-reminder'; -- ★要置換
+  v_secret text := 'YOUR_CRON_SECRET';                          -- ★要置換
+begin
+  if exists (select 1 from vault.secrets where name = 'reminder_endpoint_url') then
+    perform vault.update_secret(
+      (select id from vault.secrets where name = 'reminder_endpoint_url'),
+      v_url
+    );
+  else
+    perform vault.create_secret(v_url, 'reminder_endpoint_url');
+  end if;
+
+  if exists (select 1 from vault.secrets where name = 'cron_secret') then
+    perform vault.update_secret(
+      (select id from vault.secrets where name = 'cron_secret'),
+      v_secret
+    );
+  else
+    perform vault.create_secret(v_secret, 'cron_secret');
+  end if;
+end $$;
+
+-- 3) 既存の同名ジョブがあれば一旦解除してから登録し直す (ベキ等)。
+select cron.unschedule('daily-reminder')
+where exists (select 1 from cron.job where jobname = 'daily-reminder');
+
+-- 4) JST 11:00 = 02:00 UTC ちょうどに /api/cron/daily-reminder を叩く。
+--    エンドポイントは GET + Authorization: Bearer <CRON_SECRET> を要求するため
+--    net.http_get で Authorization ヘッダを付与する。
+--    URL / シークレットは Vault から復号して参照する。
+select cron.schedule(
+  'daily-reminder',
+  '0 2 * * *',
+  $job$
+  select net.http_get(
+    url := (select decrypted_secret from vault.decrypted_secrets where name = 'reminder_endpoint_url'),
+    headers := jsonb_build_object(
+      'Authorization',
+      'Bearer ' || (select decrypted_secret from vault.decrypted_secrets where name = 'cron_secret')
+    )
+  );
+  $job$
+);
+
+-- 確認用:
+--   登録済みジョブ        : select jobid, jobname, schedule, command from cron.job;
+--   直近の実行履歴        : select * from cron.job_run_details order by start_time desc limit 10;
+--   pg_net のレスポンス   : select * from net._http_response order by created desc limit 10;

--- a/database/daily-reminder-pg-cron.sql
+++ b/database/daily-reminder-pg-cron.sql
@@ -33,6 +33,16 @@ declare
   v_url text := 'https://YOUR-DOMAIN/api/cron/daily-reminder'; -- ★要置換
   v_secret text := 'YOUR_CRON_SECRET';                          -- ★要置換
 begin
+  -- プレースホルダのまま実行すると、認証も到達もできないジョブが静かに登録され
+  -- 本番障害につながる。値が未置換なら fail-fast して気付けるようにする。
+  if v_url = 'https://YOUR-DOMAIN/api/cron/daily-reminder'
+     or v_secret = 'YOUR_CRON_SECRET' then
+    raise exception 'daily-reminder-pg-cron.sql: v_url / v_secret を実値に置換してから実行してください';
+  end if;
+  if v_url !~ '^https://.+' then
+    raise exception 'daily-reminder-pg-cron.sql: v_url は絶対 https URL である必要があります (現在: %)', v_url;
+  end if;
+
   if exists (select 1 from vault.secrets where name = 'reminder_endpoint_url') then
     perform vault.update_secret(
       (select id from vault.secrets where name = 'reminder_endpoint_url'),
@@ -60,6 +70,9 @@ where exists (select 1 from cron.job where jobname = 'daily-reminder');
 --    エンドポイントは GET + Authorization: Bearer <CRON_SECRET> を要求するため
 --    net.http_get で Authorization ヘッダを付与する。
 --    URL / シークレットは Vault から復号して参照する。
+--    timeout_milliseconds は pg_net のデフォルト (2000ms) だと、コールドスタートや
+--    購読者が多い場合に /api/cron/daily-reminder の処理が 2 秒を超えて DB 側が先に
+--    タイムアウトし、配信が中断・誤失敗扱いになる恐れがある。余裕を持って 30 秒にする。
 select cron.schedule(
   'daily-reminder',
   '0 2 * * *',
@@ -69,7 +82,8 @@ select cron.schedule(
     headers := jsonb_build_object(
       'Authorization',
       'Bearer ' || (select decrypted_secret from vault.decrypted_secrets where name = 'cron_secret')
-    )
+    ),
+    timeout_milliseconds := 30000
   );
   $job$
 );

--- a/src/app/api/cron/daily-reminder/route.ts
+++ b/src/app/api/cron/daily-reminder/route.ts
@@ -10,7 +10,8 @@ import { sendPushBatch } from '@/services/webPushSender';
 /**
  * GET /api/cron/daily-reminder
  *
- * Vercel Cron から定期的に呼び出されるエンドポイント。
+ * 定期実行スケジューラ (Supabase pg_cron) から JST 11:00 に呼び出されるエンドポイント。
+ * スケジュール定義は database/daily-reminder-pg-cron.sql を参照。
  * - Authorization: Bearer ${CRON_SECRET} で認証
  * - 配信対象ユーザーを抽出 → ユーザーごとに並列で Web Push 送信
  * - 失効サブスクリプション (HTTP 404/410) は is_active=false に更新

--- a/src/services/reminderService.ts
+++ b/src/services/reminderService.ts
@@ -4,7 +4,9 @@ import type { NotificationPreferences, PushSubscription } from '@/types/push';
 /**
  * 週次リマインダーのスケジューリング・配信対象決定ロジック。
  *
- * Vercel Cron から JST 11:00 (= 02:00 UTC) に 1 日 1 回呼び出される前提。
+ * Supabase pg_cron から JST 11:00 (= 02:00 UTC) に 1 日 1 回呼び出される前提。
+ * (Vercel Cron は起動時刻が数十分ブレるため pg_cron に置き換えた。
+ *  database/daily-reminder-pg-cron.sql を参照)
  * - ユーザーが設定した配信曜日 (reminder_weekday) と、ローカルタイムゾーンでの
  *   "今日の曜日" が一致するユーザーを抽出
  * - 該当ユーザーの有効な push_subscriptions を取得

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,1 @@
-{
-  "crons": [
-    {
-      "path": "/api/cron/daily-reminder",
-      "schedule": "0 2 * * *"
-    }
-  ]
-}
+{}


### PR DESCRIPTION
## 概要
日次リマインダー通知の配信時刻が「中途半端な時刻」(例: 11:00 予定が 11:22〜11:23) になっていた問題を、Vercel Cron から Supabase pg_cron への移行で解消する。

## 変更内容
- `database/daily-reminder-pg-cron.sql` を追加: pg_cron + pg_net で `/api/cron/daily-reminder` を `0 2 * * *`(02:00 UTC = JST 11:00)ちょうどに叩く。秘密情報(エンドポイント URL・`CRON_SECRET`)は Supabase Vault に保存し、ベキ等(再実行可能)
- `vercel.json` から Vercel Cron 定義を削除し二重スケジュールを防止(重複送信は既存の `last_notified_at` でも防止済み)
- 関連コメント(`reminderService.ts` / `daily-reminder/route.ts`)と `database/README.md`(Phase 4 セットアップ手順)を pg_cron 前提に更新

## 動機・背景
Vercel Cron は起動時刻が数十分ブレるため、`0 2 * * *` を指定しても実際の配信が 11:22 など中途半端な時刻になり、ユーザーには「指定時刻に来ない」ように見えていた。

Postgres 内部のバックグラウンドワーカーが毎分スケジュールを評価する pg_cron は指定した分ちょうどに起動するため、配信時刻を JST 11:00 に揃えられる。pg_cron / pg_net は Supabase 無料プランでも利用可能で**追加コストは発生しない**。

## テスト
- [x] ユニットテスト (`reminderService.test.ts` 11件パス)
- [ ] 統合テスト
- [ ] 手動テスト

> 注: `daily-reminder-pg-cron.sql` の `reminder_endpoint_url` と `cron_secret` を環境に合わせて置換し、Supabase SQL Editor で実行する作業が別途必要(手順は `database/README.md` Phase 4 参照)。

## スクリーンショット
なし(UI 変更なし)

## チェックリスト
- [ ] pnpm lint:fixを行った
- [ ] CodeRabbitで問題がない
- [ ] `pnpm run build`で問題が出ない
- [ ] Vercel botで問題が出ない
- [x] テストが通る
- [x] ドキュメントを更新した（必要に応じて）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJ5aquKrCJkg7eixuMZMfo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daily reminders are now scheduled to run at a fixed JST time, improving timing consistency.
  * Added database setup steps to configure and verify the new scheduler.

* **Bug Fixes**
  * Reduced delivery-time drift by moving away from the previous scheduling approach.
  * Added safeguards to avoid duplicate schedules while still preventing duplicate sends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->