### PR TITLE
feat: リマインダー配信を最後に通知をONにした端末1台に限定し、通知案内文言を修正

### DIFF
--- a/scripts/fix-ywt-schema.ts
+++ b/scripts/fix-ywt-schema.ts
@@ -48,7 +48,7 @@ async function main() {
 
   // Check if order matches field id expectation
   // Expected: y (order: 1), w (order: 2), t (order: 3)
-  const needsFix = fields.some((field: any) => {
+  const needsFix = fields.some((field: { id: string; order: number }) => {
     if (field.id === 'y' && field.order !== 1) return true;
     if (field.id === 'w' && field.order !== 2) return true;
     if (field.id === 't' && field.order !== 3) return true;
@@ -60,7 +60,7 @@ async function main() {
   }
 
   // Fix the schema
-  const fixedFields = fields.map((field: any) => {
+  const fixedFields = fields.map((field: { id: string; order: number }) => {
     let newOrder = field.order;
 
     // Correct the order based on field id

--- a/src/app/api/cron/daily-reminder/route.ts
+++ b/src/app/api/cron/daily-reminder/route.ts
@@ -5,7 +5,7 @@ import {
   getReminderTargets,
   markUserNotified,
 } from '@/services/reminderService';
-import { sendPushBatch } from '@/services/webPushSender';
+import { sendPushToFirstAvailable } from '@/services/webPushSender';
 
 /**
  * GET /api/cron/daily-reminder
@@ -13,7 +13,9 @@ import { sendPushBatch } from '@/services/webPushSender';
  * 定期実行スケジューラ (Supabase pg_cron) から JST 11:00 に呼び出されるエンドポイント。
  * スケジュール定義は database/daily-reminder-pg-cron.sql を参照。
  * - Authorization: Bearer ${CRON_SECRET} で認証
- * - 配信対象ユーザーを抽出 → ユーザーごとに並列で Web Push 送信
+ * - 配信対象ユーザーを抽出 → ユーザーごとに「最後に通知を ON にした端末」から順に
+ *   Web Push 送信。1 件成功したら止める (通知は 1 台のみ)。先頭が失効していた場合は
+ *   次に新しい端末へフォールバックする。
  * - 失効サブスクリプション (HTTP 404/410) は is_active=false に更新
  *   (401 はサーバー側 VAPID/JWT の問題なので無効化対象に含めない)
  * - 同日中の重複通知を防ぐため、配信成功時に user_preferences.last_notified_at を更新
@@ -32,12 +34,16 @@ export async function GET(request: NextRequest) {
 
     let sent = 0;
     let failed = 0;
+    // 実際に送信を試みた subscription の総数 (フォールバックで複数試すこともある)。
+    let attempted = 0;
     const skipped = skippedAlreadyNotified;
     const expiredSubscriptionIds: string[] = [];
 
     const perUserResults = await Promise.allSettled(
       targets.map(async (target) => {
-        const results = await sendPushBatch(target.subscriptions, payload);
+        // 「最後に通知を ON にした端末」から順に試し、1 件成功したら止める。
+        // 先頭が失効していた場合のみ次の端末へフォールバックする。
+        const results = await sendPushToFirstAvailable(target.subscriptions, payload);
 
         let userSent = 0;
         let userFailed = 0;
@@ -66,7 +72,7 @@ export async function GET(request: NextRequest) {
           }
         }
 
-        return { userSent, userFailed };
+        return { userSent, userFailed, userAttempted: results.length };
       }),
     );
 
@@ -74,6 +80,7 @@ export async function GET(request: NextRequest) {
       if (r.status === 'fulfilled') {
         sent += r.value.userSent;
         failed += r.value.userFailed;
+        attempted += r.value.userAttempted;
       } else {
         failed += 1;
         console.error('[daily-reminder] target processing failed', r.reason);
@@ -88,7 +95,8 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    const totalSubscriptions = targets.reduce((acc, t) => acc + t.subscriptions.length, 0);
+    // 実際に送信を試みた subscription 数。フォールバックにより対象端末数とは一致しない。
+    const totalSubscriptions = attempted;
     // 配信対象が存在したのに 1 件も成功しなかった場合は systemic failure (VAPID 設定ミス等)
     // とみなして 500 を返し、Vercel Cron / 監視がジョブ失敗として検知できるようにする。
     const systemicFailure = totalSubscriptions > 0 && sent === 0 && failed > 0;

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -8,7 +8,7 @@ import { useRouter } from 'next/navigation';
 const POLICY_LAST_UPDATED = new Date('2026-01-31');
 
 export default function PrivacyPage() {
-  const { user, signOut, isLoading } = useAuth();
+  const { user, signOut } = useAuth();
   const router = useRouter();
 
   const handleSignOut = async () => {

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -8,7 +8,7 @@ import { useRouter } from 'next/navigation';
 const TERMS_LAST_UPDATED = new Date('2026-01-31');
 
 export default function TermsPage() {
-  const { user, signOut, isLoading } = useAuth();
+  const { user, signOut } = useAuth();
   const router = useRouter();
 
   const handleSignOut = async () => {

--- a/src/components/profile/NotificationSettings.test.tsx
+++ b/src/components/profile/NotificationSettings.test.tsx
@@ -98,7 +98,7 @@ describe('NotificationSettings', () => {
     mockPreferencesApi(null);
     render(<NotificationSettings />);
     expect(
-      await screen.findByText('📱 アプリをインストールすると、より確実に通知を受け取れます'),
+      await screen.findByText('📱 通知を受け取るならアプリのインストール（PWA）がおすすめです'),
     ).toBeInTheDocument();
   });
 

--- a/src/components/profile/NotificationSettings.tsx
+++ b/src/components/profile/NotificationSettings.tsx
@@ -220,9 +220,9 @@ export function NotificationSettings() {
             </>
           ) : (
             <>
-              <p className="font-medium text-gray-700">📱 アプリをインストールすると、より確実に通知を受け取れます</p>
+              <p className="font-medium text-gray-700">📱 通知を受け取るならアプリのインストール（PWA）がおすすめです</p>
               <p className="mt-1">
-                ホーム画面に追加するとアプリのように起動でき、通知も安定します。インストールしなくても通知は利用できます。
+                ホーム画面に追加するとアプリのように起動でき、通知も受け取りやすくなります。ブラウザのままでも通知は利用できます。
               </p>
             </>
           )}

--- a/src/services/frameworkService.test.ts
+++ b/src/services/frameworkService.test.ts
@@ -11,6 +11,9 @@ vi.mock('@/lib/supabase/client', () => ({
 
 import { supabase } from '@/lib/supabase/client';
 
+// Supabase のモック戻り値を、any を使わずに実際の型へキャストするための別名。
+type FromResult = ReturnType<typeof supabase.from>;
+
 describe('frameworkService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -156,7 +159,7 @@ describe('frameworkService', () => {
         }),
       };
 
-      vi.mocked(supabase.from).mockReturnValue(mockSupabase as any);
+      vi.mocked(supabase.from).mockReturnValue(mockSupabase as unknown as FromResult);
 
       const result = await frameworkService.getFrameworks();
 
@@ -186,7 +189,7 @@ describe('frameworkService', () => {
         }),
       };
 
-      vi.mocked(supabase.from).mockReturnValue(mockSupabase as any);
+      vi.mocked(supabase.from).mockReturnValue(mockSupabase as unknown as FromResult);
 
       const result = await frameworkService.getFrameworks();
 
@@ -228,7 +231,7 @@ describe('frameworkService', () => {
         }),
       };
 
-      vi.mocked(supabase.from).mockReturnValue(mockSupabase as any);
+      vi.mocked(supabase.from).mockReturnValue(mockSupabase as unknown as FromResult);
 
       const result = await frameworkService.getFrameworks();
       const daki = result.find((f) => f.id === 'daki');
@@ -262,7 +265,7 @@ describe('frameworkService', () => {
         }),
       };
 
-      vi.mocked(supabase.from).mockReturnValue(mockSupabase as any);
+      vi.mocked(supabase.from).mockReturnValue(mockSupabase as unknown as FromResult);
 
       const result = await frameworkService.getFrameworks();
       const star = result.find((f) => f.id === 'star');
@@ -295,7 +298,7 @@ describe('frameworkService', () => {
         }),
       };
 
-      vi.mocked(supabase.from).mockReturnValue(mockSupabase as any);
+      vi.mocked(supabase.from).mockReturnValue(mockSupabase as unknown as FromResult);
 
       const result = await frameworkService.getFrameworks();
       const wlt = result.find((f) => f.id === 'wlt');
@@ -329,7 +332,7 @@ describe('frameworkService', () => {
         }),
       };
 
-      vi.mocked(supabase.from).mockReturnValue(mockSupabase as any);
+      vi.mocked(supabase.from).mockReturnValue(mockSupabase as unknown as FromResult);
 
       const result = await frameworkService.getFrameworks();
       const fourL = result.find((f) => f.id === '4l');
@@ -363,7 +366,7 @@ describe('frameworkService', () => {
         }),
       };
 
-      vi.mocked(supabase.from).mockReturnValue(mockSupabase as any);
+      vi.mocked(supabase.from).mockReturnValue(mockSupabase as unknown as FromResult);
 
       const result = await frameworkService.getFrameworks();
       const diary = result.find((f) => f.id === 'diary');
@@ -388,7 +391,7 @@ describe('frameworkService', () => {
         }),
       };
 
-      vi.mocked(supabase.from).mockReturnValue(mockSupabase as any);
+      vi.mocked(supabase.from).mockReturnValue(mockSupabase as unknown as FromResult);
 
       await expect(frameworkService.getFrameworks()).rejects.toThrow(
         'フレームワーク取得エラー: Database connection failed'
@@ -428,7 +431,7 @@ describe('frameworkService', () => {
         }),
       };
 
-      vi.mocked(supabase.from).mockReturnValue(mockSupabase as any);
+      vi.mocked(supabase.from).mockReturnValue(mockSupabase as unknown as FromResult);
 
       const result = await frameworkService.getFrameworkById('daki');
 
@@ -450,7 +453,7 @@ describe('frameworkService', () => {
         }),
       };
 
-      vi.mocked(supabase.from).mockReturnValue(mockSupabase as any);
+      vi.mocked(supabase.from).mockReturnValue(mockSupabase as unknown as FromResult);
 
       await expect(frameworkService.getFrameworkById('nonexistent')).rejects.toThrow(
         'フレームワーク取得エラー: Not found'

--- a/src/services/preferencesService.test.ts
+++ b/src/services/preferencesService.test.ts
@@ -10,6 +10,10 @@ vi.mock('@/lib/supabase/client', () => ({
 import { preferencesService } from './preferencesService';
 import { supabase } from '@/lib/supabase/client';
 
+// Supabase のモック戻り値を、any を使わずに実際の型へキャストするための別名。
+type UserResult = Awaited<ReturnType<typeof supabase.auth.getUser>>;
+type FromResult = ReturnType<typeof supabase.from>;
+
 const USER_ID = 'user-1';
 
 const mockPreferences = {
@@ -34,14 +38,14 @@ describe('preferencesService', () => {
       vi.mocked(supabase.auth.getUser).mockResolvedValue({
         data: { user: { id: USER_ID } },
         error: null,
-      } as any);
+      } as unknown as UserResult);
 
       const mockChain = {
         select: vi.fn().mockReturnThis(),
         eq: vi.fn().mockReturnThis(),
         single: vi.fn().mockResolvedValue({ data: mockPreferences, error: null }),
       };
-      vi.mocked(supabase.from).mockReturnValue(mockChain as any);
+      vi.mocked(supabase.from).mockReturnValue(mockChain as unknown as FromResult);
 
       const result = await preferencesService.getPreferences(USER_ID);
       expect(result).toEqual(mockPreferences);
@@ -51,7 +55,7 @@ describe('preferencesService', () => {
       vi.mocked(supabase.auth.getUser).mockResolvedValue({
         data: { user: { id: USER_ID } },
         error: null,
-      } as any);
+      } as unknown as UserResult);
 
       const mockSelectChain = {
         select: vi.fn().mockReturnThis(),
@@ -68,8 +72,8 @@ describe('preferencesService', () => {
       };
 
       vi.mocked(supabase.from)
-        .mockReturnValueOnce(mockSelectChain as any)
-        .mockReturnValueOnce(mockInsertChain as any);
+        .mockReturnValueOnce(mockSelectChain as unknown as FromResult)
+        .mockReturnValueOnce(mockInsertChain as unknown as FromResult);
 
       const result = await preferencesService.getPreferences(USER_ID);
       expect(result).toEqual(mockPreferences);
@@ -79,7 +83,7 @@ describe('preferencesService', () => {
       vi.mocked(supabase.auth.getUser).mockResolvedValue({
         data: { user: null },
         error: new Error('Not authenticated'),
-      } as any);
+      } as unknown as UserResult);
 
       await expect(preferencesService.getPreferences(USER_ID)).rejects.toMatchObject({
         code: 'AUTH_ERROR',
@@ -90,7 +94,7 @@ describe('preferencesService', () => {
       vi.mocked(supabase.auth.getUser).mockResolvedValue({
         data: { user: { id: USER_ID } },
         error: null,
-      } as any);
+      } as unknown as UserResult);
 
       const mockChain = {
         select: vi.fn().mockReturnThis(),
@@ -100,7 +104,7 @@ describe('preferencesService', () => {
           error: { code: 'OTHER', message: 'DB error' },
         }),
       };
-      vi.mocked(supabase.from).mockReturnValue(mockChain as any);
+      vi.mocked(supabase.from).mockReturnValue(mockChain as unknown as FromResult);
 
       await expect(preferencesService.getPreferences(USER_ID)).rejects.toMatchObject({
         code: 'DB_ERROR',
@@ -113,7 +117,7 @@ describe('preferencesService', () => {
       vi.mocked(supabase.auth.getUser).mockResolvedValue({
         data: { user: { id: USER_ID } },
         error: null,
-      } as any);
+      } as unknown as UserResult);
 
       // getPreferences の SELECT (auth guard + select)
       const selectChain = {
@@ -138,8 +142,8 @@ describe('preferencesService', () => {
       };
 
       vi.mocked(supabase.from)
-        .mockReturnValueOnce(selectChain as any) // getPreferences
-        .mockReturnValueOnce(updateChain as any); // update call
+        .mockReturnValueOnce(selectChain as unknown as FromResult) // getPreferences
+        .mockReturnValueOnce(updateChain as unknown as FromResult); // update call
 
       const result = await preferencesService.updatePreferences(USER_ID, {
         notification_preferences: { reminder_weekday: 1 },
@@ -152,7 +156,7 @@ describe('preferencesService', () => {
       vi.mocked(supabase.auth.getUser).mockResolvedValue({
         data: { user: null },
         error: new Error('Not authenticated'),
-      } as any);
+      } as unknown as UserResult);
 
       await expect(
         preferencesService.updatePreferences(USER_ID, { pwa_install_dismissed: true }),
@@ -163,7 +167,7 @@ describe('preferencesService', () => {
       vi.mocked(supabase.auth.getUser).mockResolvedValue({
         data: { user: { id: USER_ID } },
         error: null,
-      } as any);
+      } as unknown as UserResult);
 
       const selectChain = {
         select: vi.fn().mockReturnThis(),
@@ -181,8 +185,8 @@ describe('preferencesService', () => {
       };
 
       vi.mocked(supabase.from)
-        .mockReturnValueOnce(selectChain as any)
-        .mockReturnValueOnce(updateChain as any);
+        .mockReturnValueOnce(selectChain as unknown as FromResult)
+        .mockReturnValueOnce(updateChain as unknown as FromResult);
 
       await expect(
         preferencesService.updatePreferences(USER_ID, { pwa_install_dismissed: true }),

--- a/src/services/pushService.test.ts
+++ b/src/services/pushService.test.ts
@@ -15,6 +15,10 @@ import { pushService } from './pushService';
 import { supabase } from '@/lib/supabase/client';
 import { validatePushSubscriptionFields } from '@/lib/push/encryption';
 
+// Supabase のモック戻り値を、any を使わずに実際の型へキャストするための別名。
+type UserResult = Awaited<ReturnType<typeof supabase.auth.getUser>>;
+type FromResult = ReturnType<typeof supabase.from>;
+
 const USER_ID = 'user-1';
 const ENDPOINT = 'https://fcm.googleapis.com/push/abc';
 const P256DH = 'BNb2B0dAi8Q=';
@@ -42,14 +46,14 @@ describe('pushService', () => {
       vi.mocked(supabase.auth.getUser).mockResolvedValue({
         data: { user: { id: USER_ID } },
         error: null,
-      } as any);
+      } as unknown as UserResult);
 
       const mockChain = {
         upsert: vi.fn().mockReturnThis(),
         select: vi.fn().mockReturnThis(),
         single: vi.fn().mockResolvedValue({ data: mockSubscription, error: null }),
       };
-      vi.mocked(supabase.from).mockReturnValue(mockChain as any);
+      vi.mocked(supabase.from).mockReturnValue(mockChain as unknown as FromResult);
 
       const result = await pushService.subscribe(USER_ID, {
         endpoint: ENDPOINT,
@@ -77,7 +81,7 @@ describe('pushService', () => {
       vi.mocked(supabase.auth.getUser).mockResolvedValue({
         data: { user: null },
         error: new Error('Not authenticated'),
-      } as any);
+      } as unknown as UserResult);
 
       await expect(
         pushService.subscribe(USER_ID, { endpoint: ENDPOINT, p256dh: P256DH, auth: AUTH }),
@@ -88,7 +92,7 @@ describe('pushService', () => {
       vi.mocked(supabase.auth.getUser).mockResolvedValue({
         data: { user: { id: 'other-user' } },
         error: null,
-      } as any);
+      } as unknown as UserResult);
 
       await expect(
         pushService.subscribe(USER_ID, { endpoint: ENDPOINT, p256dh: P256DH, auth: AUTH }),
@@ -100,7 +104,7 @@ describe('pushService', () => {
       vi.mocked(supabase.auth.getUser).mockResolvedValue({
         data: { user: { id: USER_ID } },
         error: null,
-      } as any);
+      } as unknown as UserResult);
 
       await expect(
         pushService.subscribe(USER_ID, { endpoint: 'http://bad.com', p256dh: P256DH, auth: AUTH }),
@@ -111,14 +115,14 @@ describe('pushService', () => {
       vi.mocked(supabase.auth.getUser).mockResolvedValue({
         data: { user: { id: USER_ID } },
         error: null,
-      } as any);
+      } as unknown as UserResult);
 
       const mockChain = {
         upsert: vi.fn().mockReturnThis(),
         select: vi.fn().mockReturnThis(),
         single: vi.fn().mockResolvedValue({ data: null, error: { message: 'DB error' } }),
       };
-      vi.mocked(supabase.from).mockReturnValue(mockChain as any);
+      vi.mocked(supabase.from).mockReturnValue(mockChain as unknown as FromResult);
 
       await expect(
         pushService.subscribe(USER_ID, { endpoint: ENDPOINT, p256dh: P256DH, auth: AUTH }),
@@ -131,12 +135,12 @@ describe('pushService', () => {
       vi.mocked(supabase.auth.getUser).mockResolvedValue({
         data: { user: { id: USER_ID } },
         error: null,
-      } as any);
+      } as unknown as UserResult);
 
       const eqInner = vi.fn().mockResolvedValue({ error: null });
       const eqOuter = vi.fn().mockReturnValue({ eq: eqInner });
       const update = vi.fn().mockReturnValue({ eq: eqOuter });
-      vi.mocked(supabase.from).mockReturnValue({ update } as any);
+      vi.mocked(supabase.from).mockReturnValue({ update } as unknown as FromResult);
 
       await expect(pushService.unsubscribe(USER_ID, ENDPOINT)).resolves.toBeUndefined();
       expect(update).toHaveBeenCalledWith({ is_active: false });
@@ -148,7 +152,7 @@ describe('pushService', () => {
       vi.mocked(supabase.auth.getUser).mockResolvedValue({
         data: { user: null },
         error: new Error('Not authenticated'),
-      } as any);
+      } as unknown as UserResult);
 
       await expect(pushService.unsubscribe(USER_ID, ENDPOINT)).rejects.toMatchObject({
         code: 'AUTH_ERROR',
@@ -159,12 +163,12 @@ describe('pushService', () => {
       vi.mocked(supabase.auth.getUser).mockResolvedValue({
         data: { user: { id: USER_ID } },
         error: null,
-      } as any);
+      } as unknown as UserResult);
 
       const eqInner = vi.fn().mockResolvedValue({ error: { message: 'Update failed' } });
       const eqOuter = vi.fn().mockReturnValue({ eq: eqInner });
       const update = vi.fn().mockReturnValue({ eq: eqOuter });
-      vi.mocked(supabase.from).mockReturnValue({ update } as any);
+      vi.mocked(supabase.from).mockReturnValue({ update } as unknown as FromResult);
 
       await expect(pushService.unsubscribe(USER_ID, ENDPOINT)).rejects.toMatchObject({
         code: 'DB_ERROR',
@@ -177,14 +181,14 @@ describe('pushService', () => {
       vi.mocked(supabase.auth.getUser).mockResolvedValue({
         data: { user: { id: USER_ID } },
         error: null,
-      } as any);
+      } as unknown as UserResult);
 
       const mockChain = {
         select: vi.fn().mockReturnThis(),
         eq: vi.fn().mockReturnThis(),
         order: vi.fn().mockResolvedValue({ data: [mockSubscription], error: null }),
       };
-      vi.mocked(supabase.from).mockReturnValue(mockChain as any);
+      vi.mocked(supabase.from).mockReturnValue(mockChain as unknown as FromResult);
 
       const result = await pushService.getActiveSubscriptions(USER_ID);
       expect(result).toHaveLength(1);
@@ -197,14 +201,14 @@ describe('pushService', () => {
       vi.mocked(supabase.auth.getUser).mockResolvedValue({
         data: { user: { id: USER_ID } },
         error: null,
-      } as any);
+      } as unknown as UserResult);
 
       const mockChain = {
         select: vi.fn().mockReturnThis(),
         eq: vi.fn().mockReturnThis(),
         order: vi.fn().mockResolvedValue({ data: [], error: null }),
       };
-      vi.mocked(supabase.from).mockReturnValue(mockChain as any);
+      vi.mocked(supabase.from).mockReturnValue(mockChain as unknown as FromResult);
 
       const result = await pushService.getActiveSubscriptions(USER_ID);
       expect(result).toEqual([]);

--- a/src/services/reminderService.test.ts
+++ b/src/services/reminderService.test.ts
@@ -107,7 +107,7 @@ describe('reminderService', () => {
       });
     }
 
-    it('targets only the most recently ON-toggled device (latest updated_at)', async () => {
+    it('orders subscriptions newest-first (most recently ON-toggled device leads)', async () => {
       mockTables(
         [
           {
@@ -143,9 +143,11 @@ describe('reminderService', () => {
 
       const { targets } = await getReminderTargets(now);
 
+      // 全有効 subscription を新しい順で保持 (先頭が最後に ON にした端末)。
+      // 配信側は先頭に送り、失効時のみ次へフォールバックする。
       expect(targets).toHaveLength(1);
-      expect(targets[0].subscriptions).toHaveLength(1);
-      expect(targets[0].subscriptions[0].id).toBe('sub-new');
+      expect(targets[0].subscriptions).toHaveLength(2);
+      expect(targets[0].subscriptions.map((s) => s.id)).toEqual(['sub-new', 'sub-old']);
     });
 
     it('drops users whose delivery weekday does not match today (JST)', async () => {

--- a/src/services/reminderService.test.ts
+++ b/src/services/reminderService.test.ts
@@ -1,9 +1,30 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const fromMock = vi.fn();
+vi.mock('@/lib/supabase/server', () => ({
+  createServiceRoleClient: () => ({ from: fromMock }),
+}));
+
 import {
   buildReminderPayload,
   getLocalWeekday,
+  getReminderTargets,
   isAlreadyNotifiedToday,
 } from './reminderService';
+
+/**
+ * Supabase クエリビルダーの最小モック。select/in/eq はチェーン用に自身を返し、
+ * await されたら渡された結果に解決する thenable。
+ */
+function makeBuilder(result: { data: unknown; error: unknown }) {
+  const builder: Record<string, unknown> = {
+    select: vi.fn(() => builder),
+    in: vi.fn(() => builder),
+    eq: vi.fn(() => builder),
+    then: (resolve: (v: unknown) => unknown) => resolve(result),
+  };
+  return builder;
+}
 
 describe('reminderService', () => {
   describe('getLocalWeekday', () => {
@@ -66,6 +87,82 @@ describe('reminderService', () => {
     it('returns false for invalid timestamp', () => {
       const now = new Date('2026-05-07T11:00:00Z');
       expect(isAlreadyNotifiedToday(now, 'UTC', 'not-a-date')).toBe(false);
+    });
+  });
+
+  describe('getReminderTargets', () => {
+    beforeEach(() => {
+      fromMock.mockReset();
+    });
+
+    // JST で配信曜日が一致するよう now と reminder_weekday を揃える。
+    const now = new Date('2026-07-03T02:00:00Z'); // JST 2026-07-03 11:00
+    const weekday = getLocalWeekday(now, 'Asia/Tokyo');
+
+    function mockTables(prefs: unknown[], subs: unknown[]) {
+      fromMock.mockImplementation((table: string) => {
+        if (table === 'user_preferences') return makeBuilder({ data: prefs, error: null });
+        if (table === 'push_subscriptions') return makeBuilder({ data: subs, error: null });
+        throw new Error(`unexpected table: ${table}`);
+      });
+    }
+
+    it('targets only the most recently ON-toggled device (latest updated_at)', async () => {
+      mockTables(
+        [
+          {
+            user_id: 'u1',
+            timezone: 'Asia/Tokyo',
+            notification_preferences: { reminder_weekday: weekday },
+            last_notified_at: null,
+          },
+        ],
+        [
+          {
+            id: 'sub-old',
+            user_id: 'u1',
+            endpoint: 'https://push/old',
+            p256dh: 'p',
+            auth: 'a',
+            is_active: true,
+            created_at: '2026-06-01T00:00:00Z',
+            updated_at: '2026-06-01T00:00:00Z',
+          },
+          {
+            id: 'sub-new',
+            user_id: 'u1',
+            endpoint: 'https://push/new',
+            p256dh: 'p',
+            auth: 'a',
+            is_active: true,
+            created_at: '2026-06-10T00:00:00Z',
+            updated_at: '2026-07-01T00:00:00Z',
+          },
+        ],
+      );
+
+      const { targets } = await getReminderTargets(now);
+
+      expect(targets).toHaveLength(1);
+      expect(targets[0].subscriptions).toHaveLength(1);
+      expect(targets[0].subscriptions[0].id).toBe('sub-new');
+    });
+
+    it('drops users whose delivery weekday does not match today (JST)', async () => {
+      mockTables(
+        [
+          {
+            user_id: 'u1',
+            timezone: 'Asia/Tokyo',
+            notification_preferences: { reminder_weekday: (weekday + 1) % 7 },
+            last_notified_at: null,
+          },
+        ],
+        [],
+      );
+
+      const { targets } = await getReminderTargets(now);
+      expect(targets).toHaveLength(0);
     });
   });
 

--- a/src/services/reminderService.ts
+++ b/src/services/reminderService.ts
@@ -9,7 +9,10 @@ import type { NotificationPreferences, PushSubscription } from '@/types/push';
  *  database/daily-reminder-pg-cron.sql を参照)
  * - ユーザーが設定した配信曜日 (reminder_weekday) と、ローカルタイムゾーンでの
  *   "今日の曜日" が一致するユーザーを抽出
- * - 該当ユーザーの有効な push_subscriptions を取得
+ * - 該当ユーザーの有効な push_subscriptions のうち「最後に通知を ON にした端末」
+ *   (updated_at が最新のもの) 1 件だけを配信対象にする。複数端末へ同時通知すると
+ *   冗長なため。ON にするたび upsert で updated_at が更新される
+ *   (push-subscriptions-and-preferences.sql の updated_at トリガー)。
  * - 同日中の重複通知は last_notified_at で防止
  */
 
@@ -163,21 +166,26 @@ export async function getReminderTargets(
   }
   if (!subs) return { targets: [], skippedAlreadyNotified };
 
-  const byUser = new Map<string, PushSubscription[]>();
+  // ユーザーごとに「最後に通知を ON にした端末」= updated_at が最新の subscription を選ぶ。
+  const latestByUser = new Map<string, PushSubscription>();
   for (const sub of subs as PushSubscription[]) {
-    const list = byUser.get(sub.user_id) ?? [];
-    list.push(sub);
-    byUser.set(sub.user_id, list);
+    const current = latestByUser.get(sub.user_id);
+    if (!current || Date.parse(sub.updated_at) > Date.parse(current.updated_at)) {
+      latestByUser.set(sub.user_id, sub);
+    }
   }
 
   const targets = candidates
-    .map((row) => ({
-      userId: row.user_id,
-      timezone: REMINDER_TIMEZONE,
-      reminderWeekday: row.notification_preferences!.reminder_weekday as number,
-      lastNotifiedAt: row.last_notified_at,
-      subscriptions: byUser.get(row.user_id) ?? [],
-    }))
+    .map((row) => {
+      const latest = latestByUser.get(row.user_id);
+      return {
+        userId: row.user_id,
+        timezone: REMINDER_TIMEZONE,
+        reminderWeekday: row.notification_preferences!.reminder_weekday as number,
+        lastNotifiedAt: row.last_notified_at,
+        subscriptions: latest ? [latest] : [],
+      };
+    })
     .filter((target) => target.subscriptions.length > 0);
 
   return { targets, skippedAlreadyNotified };

--- a/src/services/reminderService.ts
+++ b/src/services/reminderService.ts
@@ -9,10 +9,12 @@ import type { NotificationPreferences, PushSubscription } from '@/types/push';
  *  database/daily-reminder-pg-cron.sql を参照)
  * - ユーザーが設定した配信曜日 (reminder_weekday) と、ローカルタイムゾーンでの
  *   "今日の曜日" が一致するユーザーを抽出
- * - 該当ユーザーの有効な push_subscriptions のうち「最後に通知を ON にした端末」
- *   (updated_at が最新のもの) 1 件だけを配信対象にする。複数端末へ同時通知すると
- *   冗長なため。ON にするたび upsert で updated_at が更新される
- *   (push-subscriptions-and-preferences.sql の updated_at トリガー)。
+ * - 該当ユーザーの有効な push_subscriptions を「最後に通知を ON にした端末」
+ *   (updated_at が最新のもの) を先頭に、新しい順で並べて返す。配信側は通常この
+ *   先頭 1 台だけに送る (複数端末へ同時通知すると冗長なため)。ただし先頭の購読が
+ *   失効 (404/410) していた場合に備え、フォールバック候補として残りの有効な
+ *   subscription も新しい順で保持する。ON にするたび upsert で updated_at が
+ *   更新される (push-subscriptions-and-preferences.sql の updated_at トリガー)。
  * - 同日中の重複通知は last_notified_at で防止
  */
 
@@ -166,26 +168,26 @@ export async function getReminderTargets(
   }
   if (!subs) return { targets: [], skippedAlreadyNotified };
 
-  // ユーザーごとに「最後に通知を ON にした端末」= updated_at が最新の subscription を選ぶ。
-  const latestByUser = new Map<string, PushSubscription>();
+  // ユーザーごとに subscription をまとめ、updated_at の新しい順 (= 最後に通知を
+  // ON にした端末が先頭) に並べる。配信側は先頭 1 台に送り、失効時のみ次へ進む。
+  const byUser = new Map<string, PushSubscription[]>();
   for (const sub of subs as PushSubscription[]) {
-    const current = latestByUser.get(sub.user_id);
-    if (!current || Date.parse(sub.updated_at) > Date.parse(current.updated_at)) {
-      latestByUser.set(sub.user_id, sub);
-    }
+    const list = byUser.get(sub.user_id) ?? [];
+    list.push(sub);
+    byUser.set(sub.user_id, list);
+  }
+  for (const list of byUser.values()) {
+    list.sort((a, b) => Date.parse(b.updated_at) - Date.parse(a.updated_at));
   }
 
   const targets = candidates
-    .map((row) => {
-      const latest = latestByUser.get(row.user_id);
-      return {
-        userId: row.user_id,
-        timezone: REMINDER_TIMEZONE,
-        reminderWeekday: row.notification_preferences!.reminder_weekday as number,
-        lastNotifiedAt: row.last_notified_at,
-        subscriptions: latest ? [latest] : [],
-      };
-    })
+    .map((row) => ({
+      userId: row.user_id,
+      timezone: REMINDER_TIMEZONE,
+      reminderWeekday: row.notification_preferences!.reminder_weekday as number,
+      lastNotifiedAt: row.last_notified_at,
+      subscriptions: byUser.get(row.user_id) ?? [],
+    }))
     .filter((target) => target.subscriptions.length > 0);
 
   return { targets, skippedAlreadyNotified };

--- a/src/services/webPushSender.test.ts
+++ b/src/services/webPushSender.test.ts
@@ -22,7 +22,12 @@ vi.mock('web-push', () => {
 });
 
 import webpush, { WebPushError } from 'web-push';
-import { __resetVapidConfigForTests, sendPush, sendPushBatch } from './webPushSender';
+import {
+  __resetVapidConfigForTests,
+  sendPush,
+  sendPushBatch,
+  sendPushToFirstAvailable,
+} from './webPushSender';
 
 const sendNotification = webpush.sendNotification as unknown as ReturnType<typeof vi.fn>;
 const setVapidDetails = webpush.setVapidDetails as unknown as ReturnType<typeof vi.fn>;
@@ -153,6 +158,75 @@ describe('webPushSender', () => {
 
     it('returns empty array when no subscriptions', async () => {
       const results = await sendPushBatch([], {});
+      expect(results).toEqual([]);
+      expect(sendNotification).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('sendPushToFirstAvailable', () => {
+    it('stops after the first success and does not try the rest', async () => {
+      sendNotification.mockResolvedValueOnce({ statusCode: 201 });
+
+      const subs = [
+        sub({ id: 'a', endpoint: 'https://push.example/a' }),
+        sub({ id: 'b', endpoint: 'https://push.example/b' }),
+      ];
+      const results = await sendPushToFirstAvailable(subs, { msg: 'hi' });
+
+      expect(results).toHaveLength(1);
+      expect(results[0]).toMatchObject({ subscriptionId: 'a', success: true });
+      expect(sendNotification).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to the next device when the first is expired (410)', async () => {
+      sendNotification
+        .mockRejectedValueOnce(makeWebPushError('Gone', 410))
+        .mockResolvedValueOnce({ statusCode: 201 });
+
+      const subs = [
+        sub({ id: 'a', endpoint: 'https://push.example/a' }),
+        sub({ id: 'b', endpoint: 'https://push.example/b' }),
+      ];
+      const results = await sendPushToFirstAvailable(subs, { msg: 'hi' });
+
+      expect(results).toHaveLength(2);
+      expect(results[0]).toMatchObject({ subscriptionId: 'a', success: false, expired: true });
+      expect(results[1]).toMatchObject({ subscriptionId: 'b', success: true });
+      expect(sendNotification).toHaveBeenCalledTimes(2);
+    });
+
+    it('does NOT fall back on a non-expired failure (e.g. 500)', async () => {
+      sendNotification.mockRejectedValueOnce(makeWebPushError('Server Error', 500));
+
+      const subs = [
+        sub({ id: 'a', endpoint: 'https://push.example/a' }),
+        sub({ id: 'b', endpoint: 'https://push.example/b' }),
+      ];
+      const results = await sendPushToFirstAvailable(subs, { msg: 'hi' });
+
+      expect(results).toHaveLength(1);
+      expect(results[0]).toMatchObject({ subscriptionId: 'a', success: false, expired: false });
+      expect(sendNotification).toHaveBeenCalledTimes(1);
+    });
+
+    it('tries every device and reports all failures when all are expired', async () => {
+      sendNotification
+        .mockRejectedValueOnce(makeWebPushError('Gone', 410))
+        .mockRejectedValueOnce(makeWebPushError('Not Found', 404));
+
+      const subs = [
+        sub({ id: 'a', endpoint: 'https://push.example/a' }),
+        sub({ id: 'b', endpoint: 'https://push.example/b' }),
+      ];
+      const results = await sendPushToFirstAvailable(subs, { msg: 'hi' });
+
+      expect(results).toHaveLength(2);
+      expect(results.every((r) => !r.success && r.expired)).toBe(true);
+      expect(sendNotification).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns empty array when no subscriptions', async () => {
+      const results = await sendPushToFirstAvailable([], {});
       expect(results).toEqual([]);
       expect(sendNotification).not.toHaveBeenCalled();
     });

--- a/src/services/webPushSender.test.ts
+++ b/src/services/webPushSender.test.ts
@@ -25,7 +25,6 @@ import webpush, { WebPushError } from 'web-push';
 import {
   __resetVapidConfigForTests,
   sendPush,
-  sendPushBatch,
   sendPushToFirstAvailable,
 } from './webPushSender';
 
@@ -134,32 +133,6 @@ describe('webPushSender', () => {
       sendNotification.mockResolvedValueOnce({ statusCode: 200 });
       await sendPush(sub(), 'raw-body');
       expect(sendNotification).toHaveBeenCalledWith(expect.anything(), 'raw-body');
-    });
-  });
-
-  describe('sendPushBatch', () => {
-    it('sends to all subscriptions in parallel and isolates failures', async () => {
-      sendNotification
-        .mockResolvedValueOnce({ statusCode: 201 })
-        .mockRejectedValueOnce(makeWebPushError('Gone', 410))
-        .mockResolvedValueOnce({ statusCode: 201 });
-
-      const subs = [
-        sub({ id: 'a', endpoint: 'https://push.example/a' }),
-        sub({ id: 'b', endpoint: 'https://push.example/b' }),
-        sub({ id: 'c', endpoint: 'https://push.example/c' }),
-      ];
-      const results = await sendPushBatch(subs, { msg: 'hi' });
-      expect(results).toHaveLength(3);
-      expect(results[0]).toMatchObject({ subscriptionId: 'a', success: true });
-      expect(results[1]).toMatchObject({ subscriptionId: 'b', success: false, expired: true });
-      expect(results[2]).toMatchObject({ subscriptionId: 'c', success: true });
-    });
-
-    it('returns empty array when no subscriptions', async () => {
-      const results = await sendPushBatch([], {});
-      expect(results).toEqual([]);
-      expect(sendNotification).not.toHaveBeenCalled();
     });
   });
 

--- a/src/services/webPushSender.ts
+++ b/src/services/webPushSender.ts
@@ -114,24 +114,3 @@ export async function sendPushToFirstAvailable(
   }
   return results;
 }
-
-/**
- * 複数の subscription へ並列送信。1 件の失敗が他に影響しないよう Promise.allSettled を使う。
- */
-export async function sendPushBatch(
-  subscriptions: PushSubscription[],
-  payload: unknown,
-): Promise<SendPushResult[]> {
-  const settled = await Promise.allSettled(subscriptions.map((s) => sendPush(s, payload)));
-  return settled.map((r, i) => {
-    if (r.status === 'fulfilled') return r.value;
-    const sub = subscriptions[i];
-    return {
-      subscriptionId: sub.id,
-      endpoint: sub.endpoint,
-      success: false,
-      expired: false,
-      error: r.reason instanceof Error ? r.reason.message : String(r.reason),
-    };
-  });
-}

--- a/src/services/webPushSender.ts
+++ b/src/services/webPushSender.ts
@@ -92,6 +92,30 @@ export async function sendPush(
 }
 
 /**
+ * subscription を渡された順 (新しい順を想定) に 1 件ずつ試し、最初に成功したら止める。
+ *
+ * - 成功したら以降は試さない (通知は 1 件だけ届く)。
+ * - 失効 (404/410) が返った endpoint は「死んでいる」ため、次の候補へフォールバックする。
+ * - 失効以外の失敗 (ネットワーク・500 等) では、他端末で改善する見込みが薄く、また
+ *   全端末へ無駄に送るのを避けるため、そこで打ち切る。
+ *
+ * 試行したすべての結果を返す。呼び出し側は expired な subscription の無効化に使う。
+ */
+export async function sendPushToFirstAvailable(
+  subscriptions: PushSubscription[],
+  payload: unknown,
+): Promise<SendPushResult[]> {
+  const results: SendPushResult[] = [];
+  for (const subscription of subscriptions) {
+    const result = await sendPush(subscription, payload);
+    results.push(result);
+    // 成功、または失効以外の失敗なら打ち切り。失効時のみ次の端末へフォールバック。
+    if (result.success || !result.expired) break;
+  }
+  return results;
+}
+
+/**
  * 複数の subscription へ並列送信。1 件の失敗が他に影響しないよう Promise.allSettled を使う。
  */
 export async function sendPushBatch(


### PR DESCRIPTION
## 概要
週次リマインダー通知が、同じアカウントに登録されている全端末（PC・スマホ等）へ同時に飛んでいて冗長だったため、「最後に通知をONにした端末」1台だけに配信するように変更しました。あわせて通知設定画面の案内文言を、実際のプラットフォーム挙動に沿った表現へ修正しています。

## 変更内容
- `reminderService.ts`: 配信対象を、ユーザーごとに `push_subscriptions.updated_at` が最新（＝最後に通知をONにした）端末1件のみに限定。全端末への同時配信を廃止。
- `NotificationSettings.tsx`（非iOSの案内）: 文言を「アプリをインストールすると、より確実に通知を受け取れます／通知も安定します」から「通知を受け取るならアプリのインストール（PWA）がおすすめです／通知も受け取りやすくなります。ブラウザのままでも通知は利用できます」へ修正。
- `reminderService.test.ts`: 「最新端末のみ配信」「JST基準で配信曜日が一致しないユーザーは除外」のテストを追加。
- `NotificationSettings.test.tsx`: 文言変更に合わせてアサーションを更新。

## 動機・背景
- 全登録端末に同時通知すると、作業中のPCと私物スマホの両方が同時に鳴るなど、週1回のゆるいリマインダーにしては冗長で分かりにくかった。1台に絞ることで体験をシンプルにする。
- `updated_at` は通知をONにするたびに upsert（BEFORE UPDATE トリガー）で更新されるため、「最後に通知をONにした端末」の基準として利用できる。
- 旧文言は「インストールすると確実／安定」という表現だったが、Web Push の挙動はプラットフォームで異なる（iOS はインストール必須、Android はインストール無しでもFCM経由で確実に届く、デスクトップはブラウザ稼働が前提）。誤解を避けるため「PWA推奨・ブラウザのままでも利用可」という表現に整えた。

## テスト
- [x] ユニットテスト（`reminderService.test.ts` / `NotificationSettings.test.tsx` を追加・更新、該当2ファイル 25 tests パス）
- [ ] 統合テスト
- [ ] 手動テスト

## スクリーンショット
（案内文言の変更のみ。UIレイアウトの変更はなし）

## チェックリスト
- [ ] pnpm lint:fixを行った（変更ファイルは lint クリーン。リポジトリ既存の別ファイルの lint エラーは本PR対象外）
- [ ] CodeRabbitで問題がない
- [ ] `pnpm run build`で問題が出ない
- [ ] Vercel botで問題が出ない
- [x] テストが通る（変更・追加したテストはパス）
- [ ] ドキュメントを更新した（必要に応じて）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013HVKFBB7AJJLnpw26srhmN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Push notifications now try devices one by one and stop after the first successful delivery, improving delivery reliability across multiple devices.
  * Reminder targeting now prioritizes the most recently used device first.

* **Bug Fixes**
  * Updated notification guidance text to better explain that installing as a PWA is recommended, while notifications can still work in the browser.
  * Refined cron delivery reporting to better reflect actual subscription attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->