### PR TITLE
test: テストスイートの失敗と unhandled rejection を修正

### DIFF
--- a/src/app/profile/page.test.tsx
+++ b/src/app/profile/page.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { useRouter } from 'next/navigation';
 import ProfilePage from './page';
 
@@ -14,11 +14,12 @@ vi.mock('@/hooks/useAuth', () => ({
 }));
 
 // Mock ProfileCard component
+// onUpdateProfile は失敗時に reject するため、実物と同様に呼び出し側で捕捉する
 vi.mock('@/components/profile/ProfileCard', () => ({
-  ProfileCard: ({ user, onUpdateProfile }: { user: { name: string }; onUpdateProfile: (name: string) => void }) => (
+  ProfileCard: ({ user, onUpdateProfile }: { user: { name: string }; onUpdateProfile: (name: string) => Promise<void> }) => (
     <div data-testid="profile-card">
       <div>{user.name}</div>
-      <button onClick={() => onUpdateProfile('新しい名前')}>Update</button>
+      <button onClick={() => onUpdateProfile('新しい名前').catch(() => {})}>Update</button>
     </div>
   ),
 }));
@@ -39,6 +40,24 @@ vi.mock('../dashboard/loading', () => ({
 }));
 
 import { useAuth } from '@/hooks/useAuth';
+import { _resetCSRFCacheForTest } from '@/lib/api/apiClient';
+
+/**
+ * apiFetch は mutation の前に /api/csrf へトークン取得のリクエストを行うため、
+ * URL で分岐して両方の呼び出しに応答を返す fetch モックを組み立てる。
+ */
+function mockFetchWithCSRF(profileResponse: { ok: boolean; status: number; json: () => Promise<unknown> }) {
+  (global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
+    if (input === '/api/csrf') {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({ token: 'test-csrf-token' }),
+      });
+    }
+    return Promise.resolve(profileResponse);
+  });
+}
 
 describe('ProfilePage', () => {
   const mockPush = vi.fn();
@@ -64,6 +83,9 @@ describe('ProfilePage', () => {
 
     // Mock fetch for API calls
     global.fetch = vi.fn();
+
+    // apiClient がモジュールスコープに CSRF トークンをキャッシュするためテスト毎に破棄する
+    _resetCSRFCacheForTest();
   });
 
   afterEach(() => {
@@ -155,8 +177,9 @@ describe('ProfilePage', () => {
     });
 
     // Mock successful API response
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    mockFetchWithCSRF({
       ok: true,
+      status: 200,
       json: async () => ({ profile: { ...mockUser, name: '新しい名前' } }),
     });
 
@@ -167,23 +190,27 @@ describe('ProfilePage', () => {
       writable: true,
     });
 
-    const { getByRole } = render(<ProfilePage />);
+    render(<ProfilePage />);
 
     // Trigger update
-    const updateButton = getByRole('button', { name: /update/i });
-    updateButton.click();
+    fireEvent.click(screen.getByRole('button', { name: /update/i }));
 
+    // 更新成功時はページがリロードされる
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith(
-        '/api/auth/profile/user-123',
-        expect.objectContaining({
-          method: 'PATCH',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        })
-      );
+      expect(mockReload).toHaveBeenCalled();
     });
+
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
+    const patchCall = fetchMock.mock.calls.find(([url]) => url === '/api/auth/profile/user-123');
+    expect(patchCall).toBeDefined();
+
+    const [, init] = patchCall as [string, RequestInit];
+    expect(init.method).toBe('PATCH');
+    expect(init.body).toBe(JSON.stringify({ name: '新しい名前' }));
+
+    const headers = new Headers(init.headers);
+    expect(headers.get('Content-Type')).toBe('application/json');
+    expect(headers.get('X-CSRF-Token')).toBe('test-csrf-token');
   });
 
   it('should display error when profile update fails', async () => {
@@ -196,8 +223,9 @@ describe('ProfilePage', () => {
     });
 
     // Mock failed API response
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    mockFetchWithCSRF({
       ok: false,
+      status: 500,
       json: async () => ({ error: 'Update failed' }),
     });
 
@@ -206,6 +234,14 @@ describe('ProfilePage', () => {
     // Wait for component to render
     await waitFor(() => {
       expect(screen.getByTestId('profile-card')).toBeInTheDocument();
+    });
+
+    // Trigger update
+    fireEvent.click(screen.getByRole('button', { name: /update/i }));
+
+    // 失敗時は API が返したエラーメッセージが表示される
+    await waitFor(() => {
+      expect(screen.getByText('Update failed')).toBeInTheDocument();
     });
   });
 });

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -311,7 +311,7 @@ describe("authStore - Loading State and Timeout Management", () => {
       40000
     );
 
-    it("should provide specific error message for Supabase query timeout", async () => {
+    it("should not surface an error to the user when Supabase query times out", async () => {
       const { supabase } = await import("@/lib/supabase/client");
 
       // Mock session verification to fail
@@ -333,7 +333,10 @@ describe("authStore - Loading State and Timeout Management", () => {
       await initPromise;
 
       const state = useAuthStore.getState();
-      expect(state.error).toBe("データベース接続がタイムアウトしました。");
+      // 初期化エラーはログ出力のみでユーザーには通知しない仕様 (authStore の catch ブロック参照)
+      expect(state.error).toBeNull();
+      expect(state.isLoading).toBe(false);
+      expect(state.isAuthenticated).toBe(false);
     });
   });
 

--- a/src/utils/errorHandler.test.ts
+++ b/src/utils/errorHandler.test.ts
@@ -133,9 +133,11 @@ describe('retryOperation', () => {
     const op = vi.fn().mockRejectedValue(new Error('always fails'));
 
     const promise = retryOperation(op, 3, 1000);
+    // タイマー消化中に reject されるため、先にハンドラを付けて unhandled rejection を防ぐ
+    const expectation = expect(promise).rejects.toThrow('always fails');
     await vi.runAllTimersAsync();
 
-    await expect(promise).rejects.toThrow('always fails');
+    await expectation;
     expect(op).toHaveBeenCalledTimes(3);
   });
 
@@ -151,14 +153,12 @@ describe('retryOperation', () => {
         return originalSetTimeout(fn as () => void, 0);
       });
 
-    const promise = retryOperation(op, 3, 1000);
-    await vi.runAllTimersAsync();
-
-    try {
-      await promise;
-    } catch {
+    // タイマー消化中に reject されるため、先にハンドラを付けて unhandled rejection を防ぐ
+    const promise = retryOperation(op, 3, 1000).catch(() => {
       // expected
-    }
+    });
+    await vi.runAllTimersAsync();
+    await promise;
 
     setTimeoutSpy.mockRestore();
 
@@ -217,8 +217,10 @@ describe('retryWithNetworkRecovery', () => {
   it('does not retry on non-recoverable errors', async () => {
     const op = vi.fn().mockRejectedValue(new Error('Validation failed'));
     const promise = retryWithNetworkRecovery(op, 3, 100);
+    // タイマー消化中に reject されるため、先にハンドラを付けて unhandled rejection を防ぐ
+    const expectation = expect(promise).rejects.toThrow();
     await vi.runAllTimersAsync();
-    await expect(promise).rejects.toThrow();
+    await expectation;
     expect(op).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## 概要
`pnpm test:run` が exit code 1 で落ちていた問題を修正し、テストスイート全体をグリーン(60ファイル / 668 passed / 6 skipped)にしました。テストコードのみの変更で、プロダクションコードには手を入れていません。

## 変更内容
- **`src/app/profile/page.test.tsx`**: `apiFetch` は PATCH の前に `/api/csrf` へトークン取得の fetch を行うが、モックが `mockResolvedValueOnce` で1回分しか応答を用意しておらず、2回目の呼び出しが `undefined` を返して `res.status` 参照で unhandled rejection になっていた。URL で分岐する fetch モックに変更し、CSRF ヘッダ(`X-CSRF-Token`)・リクエストボディ・成功時のリロードまで検証を追加。更新失敗時のテストも実際にボタンをクリックしてエラーメッセージ表示を検証するよう強化。`apiClient` のモジュールスコープのトークンキャッシュをテスト毎に `_resetCSRFCacheForTest()` で破棄
- **`src/stores/authStore.test.ts`**: `initialize()` の catch ブロックは「初期化エラーはログ出力のみでユーザーに通知しない」仕様(`error: null` を設定)に変わっているのに、テストが旧仕様のエラーメッセージ `データベース接続がタイムアウトしました。` を期待したままで失敗していた。現行仕様に合わせて `error: null` / `isLoading: false` / `isAuthenticated: false` を検証するよう修正
- **`src/utils/errorHandler.test.ts`**: `vi.runAllTimersAsync()` の消化中に reject される Promise にハンドラが付いておらず、Vitest が unhandled rejection として検出していた(3箇所)。タイマー消化前に rejection ハンドラを付ける形に修正

## 動機・背景
テストスイート全体を実行すると1件の失敗と複数の unhandled error で exit code 1 になっており、CI をグリーンにできない状態だったため。

## テスト
- [x] ユニットテスト
- [ ] 統合テスト
- [x] 手動テスト

`pnpm test:run` で全60ファイル / 674テスト(668 passed / 6 skipped)がパスすることを確認済み。

## スクリーンショット
UI 変更なし(テストコードのみの変更)。

## チェックリスト
- [x] pnpm lint:fixを行った(`pnpm lint --max-warnings=0` がクリーン)
- [ ] CodeRabbitで問題がない
- [ ] `pnpm run build`で問題が出ない
- [ ] Vercel botで問題が出ない
- [x] テストが通る
- [ ] ドキュメントを更新した(必要に応じて)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0155dT4SAHr3fabQB2GHuBUM

---
_Generated by [Claude Code](https://claude.ai/code/session_0155dT4SAHr3fabQB2GHuBUM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Profile updates now reflect the real save flow more reliably, including proper handling of security tokens and showing the correct success or error state.
  * Session timeout behavior no longer surfaces an unnecessary error message when sign-in checks time out.
* **Tests**
  * Updated automated coverage for profile updates, authentication timeouts, and retry handling to match current app behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->