### PR TITLE
fix: PWA再開時にセッションが失われるCookie処理を修正

### DIFF
--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -5,7 +5,7 @@ import { NextRequest } from 'next/server';
 vi.mock('@supabase/ssr', () => ({
   createServerClient: vi.fn(() => ({
     auth: {
-      getSession: vi.fn().mockResolvedValue({ data: { session: null }, error: null }),
+      getClaims: vi.fn().mockResolvedValue({ data: null, error: null }),
     },
   })),
 }));

--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -10,6 +10,7 @@ vi.mock('@supabase/ssr', () => ({
   })),
 }));
 
+import { createServerClient } from '@supabase/ssr';
 import { generateCSRFToken, CSRF_COOKIE_NAME, CSRF_HEADER_NAME } from '@/utils/csrfToken';
 import { middleware } from './middleware';
 
@@ -189,5 +190,24 @@ describe('middleware session-redirect exemptions', () => {
       makeRequest({ pathname: '/dashboard', method: 'GET' }),
     );
     expect(isRedirectStatus(res.status)).toBe(true);
+  });
+
+  it('does not redirect to /auth when getClaims fails transiently (network/JWKS error)', async () => {
+    // 一時的な検証失敗は「未ログイン」と区別し、リダイレクトせずに通す。
+    // 認可判定はルート側 (API の getUser / クライアント側ガード) が行う。
+    (createServerClient as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+      auth: {
+        getClaims: vi.fn().mockResolvedValue({
+          data: null,
+          error: new Error('fetch failed'),
+        }),
+      },
+    });
+
+    const res = await middleware(
+      makeRequest({ pathname: '/dashboard', method: 'GET' }),
+    );
+    expect(isRedirectStatus(res.status)).toBe(false);
+    expect(res.status).toBeLessThan(400);
   });
 });

--- a/middleware.ts
+++ b/middleware.ts
@@ -144,10 +144,11 @@ export async function middleware(request: NextRequest) {
   );
 
   try {
-    const {
-      data: { session },
-      error,
-    } = await supabase.auth.getSession();
+    // getSession() は cookie の内容を検証せずに返すため、ルート保護には
+    // トークン検証を伴う getClaims() を使う (Supabase 推奨)。期限切れ時の
+    // セッションリフレッシュ (setAll 経由の Cookie 更新) もここで走る。
+    const { data: claimsData, error } = await supabase.auth.getClaims();
+    const claims = claimsData?.claims ?? null;
 
     if (error) {
       console.error('Middleware session error:', error);
@@ -169,7 +170,7 @@ export async function middleware(request: NextRequest) {
     // (Cron / sendBeacon / OAuth callback / CSRF 取得など)。
     const isProtectedRoute = !isPublicRoute && !isSessionExempt(request.nextUrl.pathname);
 
-    if (isProtectedRoute && !session) {
+    if (isProtectedRoute && !claims) {
       const redirectUrl = new URL('/auth', request.url);
       const nextPath = request.nextUrl.pathname + request.nextUrl.search;
       redirectUrl.searchParams.set('next', nextPath);
@@ -177,7 +178,7 @@ export async function middleware(request: NextRequest) {
       return withSessionCookies(NextResponse.redirect(redirectUrl), response);
     }
 
-    if (request.nextUrl.pathname === '/auth' && session) {
+    if (request.nextUrl.pathname === '/auth' && claims) {
       const rawNext = request.nextUrl.searchParams.get('next') || '/dashboard';
       const safeNext = rawNext.startsWith('/') && !rawNext.startsWith('//')
         ? rawNext

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,4 +1,4 @@
-import { createServerClient, type CookieOptions } from '@supabase/ssr';
+import { createServerClient } from '@supabase/ssr';
 import { NextResponse, type NextRequest } from 'next/server';
 import {
   CSRF_COOKIE_NAME,
@@ -57,6 +57,19 @@ function isSessionExempt(pathname: string): boolean {
   return matchesPathList(pathname, SESSION_EXEMPT_PATHS);
 }
 
+/**
+ * リダイレクト用レスポンスへ、Supabase がリフレッシュ時に書き込んだ
+ * Set-Cookie を引き継ぐ。これを忘れると、更新済みトークンがブラウザに
+ * 届かず旧リフレッシュトークンが再利用され、ローテーション失効で
+ * 強制ログアウトされる。
+ */
+function withSessionCookies(target: NextResponse, source: NextResponse): NextResponse {
+  source.cookies.getAll().forEach((cookie) => {
+    target.cookies.set(cookie);
+  });
+  return target;
+}
+
 export async function middleware(request: NextRequest) {
   // /api/* かつ mutation メソッドの場合は CSRF を先に検証する。
   // Supabase セッション初期化より前に走らせて、未認証でも同じ 403 で弾く。
@@ -96,47 +109,34 @@ export async function middleware(request: NextRequest) {
     return response;
   }
 
+  // Cookie の読み書きは getAll / setAll で行う (@supabase/ssr の現行推奨)。
+  // 旧 get / set / remove API は、セッション Cookie がチャンク分割
+  // (sb-xxx-auth-token.0 / .1) された場合に set が複数回呼ばれ、その度に
+  // response を作り直す実装だと先に書いたチャンクが失われる。壊れた
+  // セッション Cookie がブラウザに残り、ランダムなログアウトを引き起こす
+  // (特にトークン期限切れ後の PWA 再開時は middleware がリフレッシュを
+  // 担うため、毎回この経路を踏んでいた)。
   const supabase = createServerClient(
     supabaseUrl,
     supabaseAnonKey,
     {
       cookies: {
-        get(name: string) {
-          const value = request.cookies.get(name)?.value;
-          return value;
+        getAll() {
+          return request.cookies.getAll();
         },
-        set(name: string, value: string, options: CookieOptions) {
-          request.cookies.set({
-            name,
-            value,
-            ...options,
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) => {
+            request.cookies.set(name, value);
           });
+          // setAll は全 Cookie を一括で受け取るため、response の再生成は
+          // 1 回で済み、書き込みが欠落しない。
           response = NextResponse.next({
             request: {
               headers: request.headers,
             },
           });
-          response.cookies.set({
-            name,
-            value,
-            ...options,
-          });
-        },
-        remove(name: string, options: CookieOptions) {
-          request.cookies.set({
-            name,
-            value: '',
-            ...options,
-          });
-          response = NextResponse.next({
-            request: {
-              headers: request.headers,
-            },
-          });
-          response.cookies.set({
-            name,
-            value: '',
-            ...options,
+          cookiesToSet.forEach(({ name, value, options }) => {
+            response.cookies.set(name, value, options);
           });
         },
       },
@@ -173,19 +173,20 @@ export async function middleware(request: NextRequest) {
       const redirectUrl = new URL('/auth', request.url);
       const nextPath = request.nextUrl.pathname + request.nextUrl.search;
       redirectUrl.searchParams.set('next', nextPath);
-      
-      return NextResponse.redirect(redirectUrl, { headers: response.headers });
+
+      return withSessionCookies(NextResponse.redirect(redirectUrl), response);
     }
 
     if (request.nextUrl.pathname === '/auth' && session) {
       const rawNext = request.nextUrl.searchParams.get('next') || '/dashboard';
-      const safeNext = rawNext.startsWith('/') && !rawNext.startsWith('//') 
-        ? rawNext 
+      const safeNext = rawNext.startsWith('/') && !rawNext.startsWith('//')
+        ? rawNext
         : '/dashboard';
-      
-      return NextResponse.redirect(new URL(safeNext, request.url), {
-        headers: response.headers,
-      });
+
+      return withSessionCookies(
+        NextResponse.redirect(new URL(safeNext, request.url)),
+        response,
+      );
     }
     return response;
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -171,6 +171,15 @@ export async function middleware(request: NextRequest) {
     const isProtectedRoute = !isPublicRoute && !isSessionExempt(request.nextUrl.pathname);
 
     if (isProtectedRoute && !claims) {
+      // 一時的な検証失敗 (認証サーバへのネットワークエラー・JWKS 取得失敗など)
+      // を「未ログイン」と混同して /auth へ飛ばすと、回線が不安定な PWA 起動
+      // 直後などに強制再ログインへ化ける。エラー時はリダイレクトせずに通し、
+      // 認可判定は各ルート (API の getUser / ページのクライアント側ガード)
+      // に委ねる。
+      if (error) {
+        return response;
+      }
+
       const redirectUrl = new URL('/auth', request.url);
       const nextPath = request.nextUrl.pathname + request.nextUrl.search;
       redirectUrl.searchParams.set('next', nextPath);

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,35 +1,12 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient, type CookieOptions } from '@supabase/ssr';
+import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
+import { createClient } from '@/lib/supabase/server';
 
-export async function POST(_request: NextRequest) {
+export async function POST() {
   try {
     const cookieStore = await cookies();
-    const supabase = createServerClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-      {
-        cookies: {
-          get(name: string) {
-            return cookieStore.get(name)?.value;
-          },
-          set(name: string, value: string, options: CookieOptions) {
-            try {
-              cookieStore.set({ name, value, ...options });
-            } catch {
-              // Silent failure
-            }
-          },
-          remove(name: string, options: CookieOptions) {
-            try {
-              cookieStore.delete({ name, ...options });
-            } catch {
-              // Silent failure
-            }
-          },
-        },
-      }
-    );
+    // Cookie の読み書き (getAll / setAll) は共通の createClient に集約。
+    const supabase = await createClient();
 
     // Supabase セッションをクリア。scope を省略するとデフォルトの 'global' に
     // なり、全デバイスのリフレッシュトークンが失効してしまう (iOS では

--- a/src/app/api/auth/profile/[userId]/route.test.ts
+++ b/src/app/api/auth/profile/[userId]/route.test.ts
@@ -34,7 +34,7 @@ describe('Profile API Route', () => {
 
   let mockSupabase: {
     auth: {
-      getSession: ReturnType<typeof vi.fn>;
+      getUser: ReturnType<typeof vi.fn>;
     };
     from: ReturnType<typeof vi.fn>;
   };
@@ -55,7 +55,7 @@ describe('Profile API Route', () => {
     // Setup Supabase mock
     mockSupabase = {
       auth: {
-        getSession: vi.fn(),
+        getUser: vi.fn(),
       },
       from: vi.fn(),
     };
@@ -67,11 +67,9 @@ describe('Profile API Route', () => {
   describe('GET /api/auth/profile/[userId]', () => {
     it('should return profile when authenticated', async () => {
       // Mock session
-      mockSupabase.auth.getSession.mockResolvedValue({
+      mockSupabase.auth.getUser.mockResolvedValue({
         data: {
-          session: {
-            user: { id: mockUserId, email: 'test@example.com' },
-          },
+          user: { id: mockUserId, email: 'test@example.com' },
         },
         error: null,
       });
@@ -106,8 +104,8 @@ describe('Profile API Route', () => {
 
     it('should return 401 when not authenticated', async () => {
       // Mock no session
-      mockSupabase.auth.getSession.mockResolvedValue({
-        data: { session: null },
+      mockSupabase.auth.getUser.mockResolvedValue({
+        data: { user: null },
         error: null,
       });
 
@@ -123,11 +121,9 @@ describe('Profile API Route', () => {
 
     it('should return 403 when accessing another user profile', async () => {
       // Mock session with different user
-      mockSupabase.auth.getSession.mockResolvedValue({
+      mockSupabase.auth.getUser.mockResolvedValue({
         data: {
-          session: {
-            user: { id: 'different-user', email: 'other@example.com' },
-          },
+          user: { id: 'different-user', email: 'other@example.com' },
         },
         error: null,
       });
@@ -144,16 +140,14 @@ describe('Profile API Route', () => {
 
     it('should create profile if not exists', async () => {
       // Mock session
-      mockSupabase.auth.getSession.mockResolvedValue({
+      mockSupabase.auth.getUser.mockResolvedValue({
         data: {
-          session: {
-            user: {
-              id: mockUserId,
-              email: 'test@example.com',
-              user_metadata: {
-                full_name: 'Test User',
-                avatar_url: 'https://example.com/avatar.jpg',
-              },
+          user: {
+            id: mockUserId,
+            email: 'test@example.com',
+            user_metadata: {
+              full_name: 'Test User',
+              avatar_url: 'https://example.com/avatar.jpg',
             },
           },
         },
@@ -203,11 +197,9 @@ describe('Profile API Route', () => {
   describe('PATCH /api/auth/profile/[userId]', () => {
     it('should update profile name when authenticated', async () => {
       // Mock session
-      mockSupabase.auth.getSession.mockResolvedValue({
+      mockSupabase.auth.getUser.mockResolvedValue({
         data: {
-          session: {
-            user: { id: mockUserId, email: 'test@example.com' },
-          },
+          user: { id: mockUserId, email: 'test@example.com' },
         },
         error: null,
       });
@@ -243,11 +235,9 @@ describe('Profile API Route', () => {
 
     it('should return 400 when name is empty', async () => {
       // Mock session
-      mockSupabase.auth.getSession.mockResolvedValue({
+      mockSupabase.auth.getUser.mockResolvedValue({
         data: {
-          session: {
-            user: { id: mockUserId, email: 'test@example.com' },
-          },
+          user: { id: mockUserId, email: 'test@example.com' },
         },
         error: null,
       });
@@ -267,11 +257,9 @@ describe('Profile API Route', () => {
 
     it('should return 400 when name is whitespace only', async () => {
       // Mock session
-      mockSupabase.auth.getSession.mockResolvedValue({
+      mockSupabase.auth.getUser.mockResolvedValue({
         data: {
-          session: {
-            user: { id: mockUserId, email: 'test@example.com' },
-          },
+          user: { id: mockUserId, email: 'test@example.com' },
         },
         error: null,
       });
@@ -291,8 +279,8 @@ describe('Profile API Route', () => {
 
     it('should return 401 when not authenticated', async () => {
       // Mock no session
-      mockSupabase.auth.getSession.mockResolvedValue({
-        data: { session: null },
+      mockSupabase.auth.getUser.mockResolvedValue({
+        data: { user: null },
         error: null,
       });
 
@@ -311,11 +299,9 @@ describe('Profile API Route', () => {
 
     it('should return 403 when updating another user profile', async () => {
       // Mock session with different user
-      mockSupabase.auth.getSession.mockResolvedValue({
+      mockSupabase.auth.getUser.mockResolvedValue({
         data: {
-          session: {
-            user: { id: 'different-user', email: 'other@example.com' },
-          },
+          user: { id: 'different-user', email: 'other@example.com' },
         },
         error: null,
       });
@@ -335,11 +321,9 @@ describe('Profile API Route', () => {
 
     it('should trim whitespace from name', async () => {
       // Mock session
-      mockSupabase.auth.getSession.mockResolvedValue({
+      mockSupabase.auth.getUser.mockResolvedValue({
         data: {
-          session: {
-            user: { id: mockUserId, email: 'test@example.com' },
-          },
+          user: { id: mockUserId, email: 'test@example.com' },
         },
         error: null,
       });

--- a/src/app/api/auth/profile/[userId]/route.ts
+++ b/src/app/api/auth/profile/[userId]/route.ts
@@ -14,16 +14,18 @@ export async function GET(
     // Cookie の読み書き (getAll / setAll) は共通の createClient に集約。
     const supabase = await createClient();
 
-    const { data: { session }, error: sessionError } = await supabase.auth.getSession();
+    // 認可判定には cookie 由来の getSession() ではなく、Supabase Auth サーバで
+    // トークンを検証する getUser() を使う。
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
 
-    if (sessionError || !session) {
+    if (authError || !user) {
       return NextResponse.json(
         { error: 'Unauthorized' },
         { status: 401 }
       );
     }
 
-    if (session.user.id !== userId) {  // params.userId → userId
+    if (user.id !== userId) {  // params.userId → userId
       return NextResponse.json(
         { error: 'Forbidden' },
         { status: 403 }
@@ -39,15 +41,15 @@ export async function GET(
     if (profileError) {
       if (profileError.code === 'PGRST116') {
         // プロフィールが存在しない場合は新規作成
-        const googleName = session.user.user_metadata?.full_name ||
-                          session.user.user_metadata?.name ||
-                          session.user.email?.split('@')[0] || 'ユーザー';
+        const googleName = user.user_metadata?.full_name ||
+                          user.user_metadata?.name ||
+                          user.email?.split('@')[0] || 'ユーザー';
 
         const { data: newProfile, error: createError } = await supabase
           .from('profiles')
           .insert({
-            id: session.user.id,
-            email: session.user.email,
+            id: user.id,
+            email: user.email,
             name: googleName,
             provider: 'google',
             created_at: new Date().toISOString(),
@@ -93,16 +95,17 @@ export async function PATCH(
 
     const supabase = await createClient();
 
-    const { data: { session }, error: sessionError } = await supabase.auth.getSession();
+    // GET と同じく、認可判定はトークン検証を伴う getUser() で行う。
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
 
-    if (sessionError || !session) {
+    if (authError || !user) {
       return NextResponse.json(
         { error: 'Unauthorized' },
         { status: 401 }
       );
     }
 
-    if (session.user.id !== userId) {
+    if (user.id !== userId) {
       return NextResponse.json(
         { error: 'Forbidden' },
         { status: 403 }

--- a/src/app/api/auth/profile/[userId]/route.ts
+++ b/src/app/api/auth/profile/[userId]/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient, type CookieOptions } from '@supabase/ssr';
-import { cookies } from 'next/headers';
+import { createClient } from '@/lib/supabase/server';
 import { ProfileUpdateSchema } from '@/lib/validation/schemas';
 import { parseJsonBody } from '@/lib/validation/parse';
 import { sanitizePlainText } from '@/utils/sanitize';
@@ -11,36 +10,12 @@ export async function GET(
 ) {
   try {
     const { userId } = await params;  // ← await を追加
-    
-    const cookieStore = await cookies();
-    const supabase = createServerClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-      {
-        cookies: {
-          get(name: string) {
-            return cookieStore.get(name)?.value;
-          },
-          set(name: string, value: string, options: CookieOptions) {
-            try {
-              cookieStore.set({ name, value, ...options });
-            } catch {
-              // Silent failure
-            }
-          },
-          remove(name: string, options: CookieOptions) {
-            try {
-              cookieStore.delete({ name, ...options });
-            } catch {
-              // Silent failure
-            }
-          },
-        },
-      }
-    );
+
+    // Cookie の読み書き (getAll / setAll) は共通の createClient に集約。
+    const supabase = await createClient();
 
     const { data: { session }, error: sessionError } = await supabase.auth.getSession();
-    
+
     if (sessionError || !session) {
       return NextResponse.json(
         { error: 'Unauthorized' },
@@ -116,32 +91,7 @@ export async function PATCH(
   try {
     const { userId } = await params;
 
-    const cookieStore = await cookies();
-    const supabase = createServerClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-      {
-        cookies: {
-          get(name: string) {
-            return cookieStore.get(name)?.value;
-          },
-          set(name: string, value: string, options: CookieOptions) {
-            try {
-              cookieStore.set({ name, value, ...options });
-            } catch {
-              // Silent failure
-            }
-          },
-          remove(name: string, options: CookieOptions) {
-            try {
-              cookieStore.delete({ name, ...options });
-            } catch {
-              // Silent failure
-            }
-          },
-        },
-      }
-    );
+    const supabase = await createClient();
 
     const { data: { session }, error: sessionError } = await supabase.auth.getSession();
 

--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient, type CookieOptions } from '@supabase/ssr';
+import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
 import { SessionCreateSchema } from '@/lib/validation/schemas';
 import { parseJsonBody } from '@/lib/validation/parse';
@@ -18,22 +18,18 @@ export async function POST(request: NextRequest) {
       process.env.NEXT_PUBLIC_SUPABASE_URL!,
       process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
       {
+        // チャンク分割されたセッション Cookie を欠落なく書き込むため
+        // getAll / setAll を使う (@supabase/ssr の現行推奨 API)。
         cookies: {
-          get(name: string) {
-            return cookieStore.get(name)?.value;
+          getAll() {
+            return cookieStore.getAll();
           },
-          set(name: string, value: string, options: CookieOptions) {
+          setAll(cookiesToSet) {
             try {
-              cookieStore.set({ name, value, ...options });
-              response.cookies.set({ name, value, ...options });
-            } catch {
-              // Silent failure
-            }
-          },
-          remove(name: string, options: CookieOptions) {
-            try {
-              cookieStore.delete({ name, ...options });
-              response.cookies.delete({ name, ...options });
+              cookiesToSet.forEach(({ name, value, options }) => {
+                cookieStore.set(name, value, options);
+                response.cookies.set(name, value, options);
+              });
             } catch {
               // Silent failure
             }

--- a/src/app/api/auth/verify/route.ts
+++ b/src/app/api/auth/verify/route.ts
@@ -1,35 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient, type CookieOptions } from '@supabase/ssr';
-import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
 
-export async function GET(_request: NextRequest) {
+export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const supabase = createServerClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-      {
-        cookies: {
-          get(name: string) {
-            return cookieStore.get(name)?.value;
-          },
-          set(name: string, value: string, options: CookieOptions) {
-            try {
-              cookieStore.set({ name, value, ...options });
-            } catch {
-              // Silent failure
-            }
-          },
-          remove(name: string, options: CookieOptions) {
-            try {
-              cookieStore.delete({ name, ...options });
-            } catch {
-              // Silent failure
-            }
-          },
-        },
-      }
-    );
+    // Cookie の読み書き (getAll / setAll) は共通の createClient に集約。
+    const supabase = await createClient();
 
     const { data: { session }, error } = await supabase.auth.getSession();
 

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,30 +1,29 @@
-import { createServerClient, type CookieOptions } from "@supabase/ssr";
+import { createServerClient } from "@supabase/ssr";
 import { createClient as createSupabaseClient, type SupabaseClient } from "@supabase/supabase-js";
 import { cookies } from "next/headers";
 
 export async function createClient() {
   const cookieStore = await cookies();
 
+  // 旧 get / set / remove API はチャンク分割されたセッション Cookie を
+  // 壊すことがある (ランダムログアウトの原因) ため、@supabase/ssr の
+  // 現行推奨である getAll / setAll を使う。
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
-        get(name: string) {
-          return cookieStore.get(name)?.value;
+        getAll() {
+          return cookieStore.getAll();
         },
-        set(name: string, value: string, options: CookieOptions) {
+        setAll(cookiesToSet) {
           try {
-            cookieStore.set({ name, value, ...options });
+            cookiesToSet.forEach(({ name, value, options }) => {
+              cookieStore.set(name, value, options);
+            });
           } catch {
-            // Silent failure
-          }
-        },
-        remove(name: string, options: CookieOptions) {
-          try {
-            cookieStore.set({ name, value: "", ...options });
-          } catch {
-            // Silent failure
+            // Server Component から呼ばれた場合、Cookie の書き込みはできない。
+            // セッションのリフレッシュと Cookie 更新は middleware が担うため無視してよい。
           }
         },
       },

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -292,17 +292,31 @@ export const useAuthStore = create<AuthStore>()(
             // プロフィール取得の失敗は致命的ではない。セッションが有効なら
             // session.user の情報でフォールバックし、ログイン状態を維持する
             // (サーバー経由の経路と同じ扱い)。
-            let profileResult: { data: ProfileData | null } | null = null;
+            let profileResult: {
+              data: ProfileData | null;
+              error: { code?: string } | null;
+            } | null = null;
             try {
               profileResult = await timeoutPromise(
-                profileQuery as unknown as Promise<{ data: ProfileData | null }>,
+                profileQuery as unknown as Promise<{
+                  data: ProfileData | null;
+                  error: { code?: string } | null;
+                }>,
                 30000
               );
             } catch (profileError) {
               console.error('[AuthStore] Profile query failed:', profileError);
             }
 
-            if (!profileResult) {
+            // Supabase クエリは失敗しても throw せず { data: null, error } で
+            // 解決する。読み取りエラーを「プロフィール未作成 (PGRST116 = 0 行)」
+            // と混同して createDefaultProfile へ進むと、既存プロフィールと
+            // 衝突して作成にも失敗し、有効なセッションがあるのに未ログイン
+            // 扱いになってしまう。読み取り失敗時はセッション情報で継続する。
+            if (
+              !profileResult ||
+              (profileResult.error != null && profileResult.error.code !== 'PGRST116')
+            ) {
               const sessionUser = session.user as SupabaseUser;
               const user: User = {
                 id: sessionUser.id,

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -174,16 +174,26 @@ export const useAuthStore = create<AuthStore>()(
             }
           };
 
-          const serverSessionResponse = await fetchWithTimeout(
-            "/api/auth/verify",
-            {
-              method: "GET",
-              credentials: "include",
-            },
-            30000
-          );
+          // /api/auth/verify への到達失敗 (オフライン・回線断・タイムアウト) を
+          // 「未ログイン」と混同しない。PWA の起動直後は回線が不安定なことが
+          // 多く、ここで throw するとセッションが生きていても認証画面へ
+          // 飛ばされてしまう。失敗時はクライアント側 (cookie) のセッション
+          // 確認へフォールバックする。
+          let serverSessionResponse: Response | null = null;
+          try {
+            serverSessionResponse = await fetchWithTimeout(
+              "/api/auth/verify",
+              {
+                method: "GET",
+                credentials: "include",
+              },
+              30000
+            );
+          } catch (verifyError) {
+            console.error("[AuthStore] Session verify request failed:", verifyError);
+          }
 
-          if (serverSessionResponse.ok) {
+          if (serverSessionResponse?.ok) {
             const serverSession = await serverSessionResponse.json();
 
             if (serverSession.authenticated) {
@@ -279,7 +289,10 @@ export const useAuthStore = create<AuthStore>()(
               .eq("id", session.user.id)
               .single();
 
-            let profileResult;
+            // プロフィール取得の失敗は致命的ではない。セッションが有効なら
+            // session.user の情報でフォールバックし、ログイン状態を維持する
+            // (サーバー経由の経路と同じ扱い)。
+            let profileResult: { data: ProfileData | null } | null = null;
             try {
               profileResult = await timeoutPromise(
                 profileQuery as unknown as Promise<{ data: ProfileData | null }>,
@@ -287,7 +300,31 @@ export const useAuthStore = create<AuthStore>()(
               );
             } catch (profileError) {
               console.error('[AuthStore] Profile query failed:', profileError);
-              throw profileError;
+            }
+
+            if (!profileResult) {
+              const sessionUser = session.user as SupabaseUser;
+              const user: User = {
+                id: sessionUser.id,
+                email: sessionUser.email || '',
+                name:
+                  sessionUser.user_metadata?.full_name ||
+                  sessionUser.user_metadata?.name ||
+                  sessionUser.email?.split('@')[0] ||
+                  'ユーザー',
+                provider: 'google',
+                avatar_url: sessionUser.user_metadata?.avatar_url,
+                created_at: new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+              };
+
+              set({
+                user,
+                isAuthenticated: true,
+                isLoading: false,
+                error: null,
+              });
+              return;
             }
 
             const { data: profile } = profileResult;


### PR DESCRIPTION
## 概要
PWA で再開するたびにすぐ再ログインを求められる問題の修正。`@supabase/ssr` の非推奨 Cookie API (`get`/`set`/`remove`) を現行推奨の `getAll`/`setAll` へ移行し、セッション Cookie の破損によるランダムログアウトを解消します。

## 変更内容
- `middleware.ts`: Cookie 処理を `getAll`/`setAll` へ移行。旧実装は Cookie の `set` がチャンクごと (`sb-xxx-auth-token.0` / `.1`) に呼ばれるたびに `NextResponse.next()` で response を作り直しており、先に書いたチャンクが失われて壊れたセッション Cookie がブラウザに残っていた。`setAll` は全 Cookie を一括で受け取るため response の再生成が 1 回で済み、欠落しない
- `middleware.ts`: `/auth` へのリダイレクト時にも、リフレッシュで更新済みの Set-Cookie を引き継ぐように修正 (`withSessionCookies`)。旧リフレッシュトークンの再利用によるローテーション失効 (強制ログアウト) を防ぐ
- `src/lib/supabase/server.ts` / `src/app/api/auth/session/route.ts`: 同様に `getAll`/`setAll` へ移行
- `src/app/api/auth/verify` / `logout` / `profile` の各 route: 重複していたインライン Cookie 処理を削除し、共通の `createClient()` (`@/lib/supabase/server`) に集約
- `src/stores/authStore.ts` の `initialize()`: `/api/auth/verify` への通信失敗 (オフライン・回線断・タイムアウト) を「未ログイン」と混同せず、クライアント側のセッション確認へフォールバック。プロフィール取得失敗時も `session.user` の情報でログイン状態を維持

## 動機・背景
PWA で「すぐ認証が求められる」報告があった。通常のブラウザタブではクライアント側の supabase-js がトークン期限前に自動更新するため顕在化しないが、PWA は OS にサスペンド/kill されるため再開時にはアクセストークン (有効期限 1 時間) が切れており、最初のナビゲーションで middleware がサーバー側リフレッシュを担う。この経路に上記のチャンク欠落バグがあり、リフレッシュのたびにセッション Cookie が壊れて `/auth` へ飛ばされていた。

Supabase 公式ドキュメントも、旧 `get`/`set`/`remove` API について「ユーザーがランダムにログアウトされる原因になるため、必ず `getAll`/`setAll` を使うこと」と明記して廃止している。

## テスト
- [x] ユニットテスト (`pnpm test:run` — 60 ファイル / 668 件パス)
- [ ] 統合テスト
- [ ] 手動テスト (PWA 実機での確認: ログイン → 1 時間以上放置 → 再開してセッションが維持されることを確認してください)

## スクリーンショット
UI 変更なし。

## チェックリスト
- [x] pnpm lint:fixを行った (`pnpm lint` クリーン)
- [ ] CodeRabbitで問題がない
- [x] `pnpm run build`で問題が出ない
- [ ] Vercel botで問題が出ない
- [x] テストが通る
- [ ] ドキュメントを更新した（必要に応じて）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUmtwzoLd5pF25KU7yLqYq

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUmtwzoLd5pF25KU7yLqYq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication redirects so protected routes and the auth page behave correctly, while preserving Supabase session cookies.
  * Made session verification more resilient to network/server failures to prevent unnecessary sign-outs.
  * Updated profile authorization to rely on the authenticated user identity (user-based checks) for correct 401/403 behavior.
  * Ensured logout consistently clears authentication cookies and improved cookie handling during session setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->