### PR TITLE
ヘッダーのナビ改善：ロゴのホームリンク化・パンくず・全画面共通メニュー

### DIFF
--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -50,8 +50,6 @@ export default function AnalyticsPage() {
         userName={user.name}
         onSignOut={handleSignOut}
         title="統計・トレンド分析"
-        showBackButton
-        backHref="/dashboard"
       />
 
       <main className="max-w-7xl mx-auto px-4 py-8">

--- a/src/app/history/[id]/page.tsx
+++ b/src/app/history/[id]/page.tsx
@@ -166,6 +166,7 @@ export default function ReflectionDetailPage() {
           userName={user?.name}
           onSignOut={handleSignOut}
           title="振り返り詳細"
+          breadcrumbs={[{ label: '振り返り履歴', href: '/history' }]}
         />
         <div className="flex items-center justify-center py-12">
           <Loader2 className="w-8 h-8 text-blue-600 animate-spin" />
@@ -181,8 +182,7 @@ export default function ReflectionDetailPage() {
         userName={user?.name}
         onSignOut={handleSignOut}
         title="振り返り詳細"
-        showBackButton={true}
-        backHref="/history"
+        breadcrumbs={[{ label: '振り返り履歴', href: '/history' }]}
       />
 
       <div className="max-w-3xl mx-auto py-8 px-4">

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -141,8 +141,6 @@ export default function HistoryPage() {
         userName={user.name}
         onSignOut={handleSignOut}
         title="振り返り履歴"
-        showBackButton={true}
-        backHref="/dashboard"
       />
 
       <main className="max-w-7xl mx-auto px-4 py-8">

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -89,8 +89,6 @@ export default function ProfilePage() {
         userName={user.name}
         onSignOut={handleSignOut}
         title="プロフィール"
-        showBackButton
-        backHref="/dashboard"
       />
 
       <main className="max-w-2xl mx-auto px-4 py-8">

--- a/src/app/reflection/page.tsx
+++ b/src/app/reflection/page.tsx
@@ -46,8 +46,6 @@ export default function ReflectionPage() {
         userName={user.name}
         onSignOut={handleSignOut}
         title="新しい振り返りを作成"
-        showBackButton={true}
-        backHref="/dashboard"
       />
 
       {/* Main Content */}

--- a/src/components/layout/Header/LoggedInHeader.tsx
+++ b/src/components/layout/Header/LoggedInHeader.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { Button } from '@/components/ui/button';
 import {
   LogOut,
   Loader2,
@@ -96,6 +95,8 @@ export default function LoggedInHeader({
     };
   }, [isMenuOpen]);
 
+  const closeMenu = () => setIsMenuOpen(false);
+
   return (
     <header className="bg-white border-b border-gray-200 sticky top-0 z-20">
       <div className="max-w-6xl mx-auto px-3 sm:px-4 py-3 sm:py-4">
@@ -146,129 +147,89 @@ export default function LoggedInHeader({
             </nav>
           )}
 
-          {/* 右側（デスクトップ）：ユーザー名 + お問い合わせ + ログアウト */}
-          <nav
-            aria-label="ユーザーメニュー"
-            className="hidden sm:flex items-center gap-4 flex-shrink-0"
-          >
-            <div className="flex items-center gap-2 text-gray-700">
-              <User className="w-4 h-4" aria-hidden="true" />
-              <span className="text-sm">{userName}</span>
-            </div>
-            {hasContact && (
-              <a
-                href={contactUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="お問い合わせ (新しいタブで開く)"
-                className="flex items-center gap-2 text-gray-700 hover:text-blue-700 transition px-3 py-1.5 rounded-md hover:bg-gray-50"
-              >
-                <Mail className="w-4 h-4" aria-hidden="true" />
-                <span className="text-sm">お問い合わせ</span>
-              </a>
-            )}
-            <Button
-              onClick={handleSignOut}
-              variant="outline"
-              size="sm"
-              disabled={isLoading}
-              aria-busy={isLoading}
-              aria-label={isLoading ? 'ログアウト中' : 'ログアウト'}
-              className="text-gray-700 hover:text-gray-900 px-3"
+          {/* 右側：メニューボタン（全画面共通）+ ドロップダウン */}
+          <div className="relative flex-shrink-0">
+            <button
+              ref={menuButtonRef}
+              type="button"
+              onClick={() => setIsMenuOpen((open) => !open)}
+              aria-expanded={isMenuOpen}
+              aria-controls="app-menu-panel"
+              aria-label={isMenuOpen ? 'メニューを閉じる' : 'メニューを開く'}
+              className="flex items-center justify-center w-10 h-10 -mr-1 rounded-md text-gray-700 hover:text-gray-900 hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             >
-              {isLoading ? (
-                <Loader2 className="w-4 h-4 animate-spin motion-reduce:animate-none" aria-hidden="true" />
+              {isMenuOpen ? (
+                <X className="w-6 h-6" aria-hidden="true" />
               ) : (
-                <LogOut className="w-4 h-4" aria-hidden="true" />
+                <Menu className="w-6 h-6" aria-hidden="true" />
               )}
-              <span className="ml-2">{isLoading ? 'ログアウト中...' : 'ログアウト'}</span>
-            </Button>
-          </nav>
+            </button>
 
-          {/* 右側（モバイル）：ハンバーガーメニュー */}
-          <button
-            ref={menuButtonRef}
-            type="button"
-            onClick={() => setIsMenuOpen((open) => !open)}
-            aria-expanded={isMenuOpen}
-            aria-controls="mobile-menu-panel"
-            aria-label={isMenuOpen ? 'メニューを閉じる' : 'メニューを開く'}
-            className="sm:hidden flex items-center justify-center w-10 h-10 -mr-1 rounded-md text-gray-700 hover:text-gray-900 hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 flex-shrink-0"
-          >
-            {isMenuOpen ? (
-              <X className="w-6 h-6" aria-hidden="true" />
-            ) : (
-              <Menu className="w-6 h-6" aria-hidden="true" />
-            )}
-          </button>
-        </div>
-      </div>
-
-      {/* モバイルメニューパネル */}
-      {isMenuOpen && (
-        <div
-          ref={menuPanelRef}
-          id="mobile-menu-panel"
-          className="sm:hidden border-t border-gray-200 bg-white shadow-sm"
-        >
-          <div className="max-w-6xl mx-auto px-3 py-3">
-            <div className="flex items-center gap-2 text-gray-700 px-2 pb-3 mb-2 border-b border-gray-100">
-              <User className="w-4 h-4" aria-hidden="true" />
-              <span className="text-sm font-medium">{userName}</span>
-            </div>
-
-            <nav aria-label="メインメニュー">
-              <ul className="flex flex-col">
-                {NAV_ITEMS.map(({ href, label, icon: Icon }) => (
-                  <li key={href}>
-                    <Link
-                      href={href}
-                      onClick={() => setIsMenuOpen(false)}
-                      className="flex items-center gap-3 px-2 py-3 rounded-md text-gray-800 hover:bg-gray-50"
-                    >
-                      <Icon className="w-5 h-5 text-gray-500" aria-hidden="true" />
-                      <span className="text-sm">{label}</span>
-                    </Link>
-                  </li>
-                ))}
-              </ul>
-            </nav>
-
-            <div className="mt-2 pt-2 border-t border-gray-100 flex flex-col">
-              {hasContact && (
-                <a
-                  href={contactUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onClick={() => setIsMenuOpen(false)}
-                  aria-label="お問い合わせ (新しいタブで開く)"
-                  className="flex items-center gap-3 px-2 py-3 rounded-md text-gray-800 hover:bg-gray-50"
-                >
-                  <Mail className="w-5 h-5 text-gray-500" aria-hidden="true" />
-                  <span className="text-sm">お問い合わせ</span>
-                </a>
-              )}
-              <button
-                type="button"
-                onClick={() => {
-                  setIsMenuOpen(false);
-                  void handleSignOut();
-                }}
-                disabled={isLoading}
-                aria-busy={isLoading}
-                className="flex items-center gap-3 px-2 py-3 rounded-md text-gray-800 hover:bg-gray-50 disabled:opacity-50 text-left"
+            {isMenuOpen && (
+              <div
+                ref={menuPanelRef}
+                id="app-menu-panel"
+                className="absolute right-0 top-full mt-2 w-64 max-w-[calc(100vw-1.5rem)] rounded-lg border border-gray-200 bg-white shadow-lg py-2 z-30"
               >
-                {isLoading ? (
-                  <Loader2 className="w-5 h-5 text-gray-500 animate-spin motion-reduce:animate-none" aria-hidden="true" />
-                ) : (
-                  <LogOut className="w-5 h-5 text-gray-500" aria-hidden="true" />
-                )}
-                <span className="text-sm">{isLoading ? 'ログアウト中...' : 'ログアウト'}</span>
-              </button>
-            </div>
+                <div className="flex items-center gap-2 text-gray-700 px-4 pb-2 mb-1 border-b border-gray-100">
+                  <User className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
+                  <span className="text-sm font-medium truncate">{userName}</span>
+                </div>
+
+                <nav aria-label="メインメニュー">
+                  <ul className="flex flex-col">
+                    {NAV_ITEMS.map(({ href, label, icon: Icon }) => (
+                      <li key={href}>
+                        <Link
+                          href={href}
+                          onClick={closeMenu}
+                          className="flex items-center gap-3 px-4 py-2.5 text-gray-800 hover:bg-gray-50"
+                        >
+                          <Icon className="w-5 h-5 text-gray-500 flex-shrink-0" aria-hidden="true" />
+                          <span className="text-sm">{label}</span>
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </nav>
+
+                <div className="mt-1 pt-1 border-t border-gray-100 flex flex-col">
+                  {hasContact && (
+                    <a
+                      href={contactUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={closeMenu}
+                      aria-label="お問い合わせ (新しいタブで開く)"
+                      className="flex items-center gap-3 px-4 py-2.5 text-gray-800 hover:bg-gray-50"
+                    >
+                      <Mail className="w-5 h-5 text-gray-500 flex-shrink-0" aria-hidden="true" />
+                      <span className="text-sm">お問い合わせ</span>
+                    </a>
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => {
+                      closeMenu();
+                      void handleSignOut();
+                    }}
+                    disabled={isLoading}
+                    aria-busy={isLoading}
+                    className="flex items-center gap-3 px-4 py-2.5 text-gray-800 hover:bg-gray-50 disabled:opacity-50 text-left"
+                  >
+                    {isLoading ? (
+                      <Loader2 className="w-5 h-5 text-gray-500 animate-spin motion-reduce:animate-none flex-shrink-0" aria-hidden="true" />
+                    ) : (
+                      <LogOut className="w-5 h-5 text-gray-500 flex-shrink-0" aria-hidden="true" />
+                    )}
+                    <span className="text-sm">{isLoading ? 'ログアウト中...' : 'ログアウト'}</span>
+                  </button>
+                </div>
+              </div>
+            )}
           </div>
         </div>
-      )}
+      </div>
     </header>
   );
 }

--- a/src/components/layout/Header/LoggedInHeader.tsx
+++ b/src/components/layout/Header/LoggedInHeader.tsx
@@ -1,29 +1,62 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
-import { LogOut, Loader2, User, ArrowLeft, Mail } from 'lucide-react';
+import {
+  LogOut,
+  Loader2,
+  User,
+  ChevronRight,
+  Mail,
+  Menu,
+  X,
+  PlusCircle,
+  Calendar,
+  BarChart3,
+  Settings,
+} from 'lucide-react';
 import Link from 'next/link';
 import { isValidUrl } from '@/utils/urlValidation';
+
+const BRAND = 'ReflectHub';
+const HOME_HREF = '/dashboard';
+
+interface Breadcrumb {
+  label: string;
+  href?: string;
+}
 
 interface LoggedInHeaderProps {
   userName: string;
   onSignOut: () => Promise<void>;
   title?: string;
-  showBackButton?: boolean;
-  backHref?: string;
+  /** 現在ページより上の階層（ブランドと現在ページは自動付与）。 */
+  breadcrumbs?: Breadcrumb[];
   contactUrl?: string;
 }
+
+/** グローバルナビの主要ページ（ダッシュボードのクイックアクションと対応）。 */
+const NAV_ITEMS = [
+  { href: '/reflection', label: '新しい振り返り', icon: PlusCircle },
+  { href: '/history', label: '履歴を見る', icon: Calendar },
+  { href: '/analytics', label: '統計を見る', icon: BarChart3 },
+  { href: '/profile', label: '設定', icon: Settings },
+] as const;
 
 export default function LoggedInHeader({
   userName,
   onSignOut,
-  title = 'ReflectHub',
-  showBackButton = false,
-  backHref = '/dashboard',
-  contactUrl
+  title = BRAND,
+  breadcrumbs = [],
+  contactUrl,
 }: LoggedInHeaderProps) {
   const [isLoading, setIsLoading] = useState(false);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
+  const menuPanelRef = useRef<HTMLDivElement>(null);
+
+  const isHome = title === BRAND && breadcrumbs.length === 0;
+  const hasContact = contactUrl != null && isValidUrl(contactUrl);
 
   const handleSignOut = async () => {
     setIsLoading(true);
@@ -34,44 +67,104 @@ export default function LoggedInHeader({
     }
   };
 
-  return (
-    <header className="bg-white border-b border-gray-200 sticky top-0 z-10">
-      <div className="max-w-6xl mx-auto px-3 sm:px-4 py-3 sm:py-4">
-        {/* タイトル行 */}
-        <div className="flex items-center justify-between gap-2 sm:gap-4">
-          {/* 左側：戻るボタン + タイトル */}
-          <div className="flex items-center gap-2 sm:gap-3 flex-1 min-w-0">
-            {showBackButton && (
-              <Link
-                href={backHref}
-                aria-label="前の画面に戻る"
-                className="flex items-center gap-1 text-gray-700 hover:text-gray-900 flex-shrink-0"
-              >
-                <ArrowLeft className="w-5 h-5" aria-hidden="true" />
-                <span className="text-xs sm:text-sm">戻る</span>
-              </Link>
-            )}
-            <h1 className="text-lg sm:text-2xl font-semibold text-gray-900 truncate">
-              {title}
-            </h1>
-          </div>
+  // メニュー: Escape で閉じてトリガーにフォーカスを戻す + 外側クリックで閉じる
+  useEffect(() => {
+    if (!isMenuOpen) return;
 
-          {/* 右側：ユーザー名 + お問い合わせ + ログアウト */}
-          <nav aria-label="ユーザーメニュー" className="flex items-center gap-2 sm:gap-4 flex-shrink-0">
-            <div className="hidden sm:flex items-center gap-2 text-gray-700">
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsMenuOpen(false);
+        menuButtonRef.current?.focus();
+      }
+    };
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node;
+      if (
+        !menuPanelRef.current?.contains(target) &&
+        !menuButtonRef.current?.contains(target)
+      ) {
+        setIsMenuOpen(false);
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    document.addEventListener('pointerdown', handlePointerDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('pointerdown', handlePointerDown);
+    };
+  }, [isMenuOpen]);
+
+  return (
+    <header className="bg-white border-b border-gray-200 sticky top-0 z-20">
+      <div className="max-w-6xl mx-auto px-3 sm:px-4 py-3 sm:py-4">
+        <div className="flex items-center justify-between gap-2 sm:gap-4">
+          {/* 左側：ロゴ + パンくず */}
+          {isHome ? (
+            <h1 className="text-lg sm:text-2xl font-semibold text-gray-900 truncate">
+              <Link href={HOME_HREF} className="hover:text-blue-700 transition-colors">
+                {BRAND}
+              </Link>
+            </h1>
+          ) : (
+            <nav aria-label="パンくずリスト" className="min-w-0 flex-1">
+              <ol className="flex items-center gap-1 sm:gap-1.5 min-w-0 text-sm">
+                <li className="flex-shrink-0">
+                  <Link
+                    href={HOME_HREF}
+                    className="font-semibold text-gray-900 hover:text-blue-700 transition-colors"
+                  >
+                    {BRAND}
+                  </Link>
+                </li>
+                {breadcrumbs.map((crumb) => (
+                  <li
+                    key={crumb.href ?? crumb.label}
+                    className="flex items-center gap-1 sm:gap-1.5 min-w-0"
+                  >
+                    <ChevronRight className="w-4 h-4 text-gray-400 flex-shrink-0" aria-hidden="true" />
+                    {crumb.href ? (
+                      <Link
+                        href={crumb.href}
+                        className="text-gray-600 hover:text-blue-700 transition-colors truncate"
+                      >
+                        {crumb.label}
+                      </Link>
+                    ) : (
+                      <span className="text-gray-600 truncate">{crumb.label}</span>
+                    )}
+                  </li>
+                ))}
+                <li className="flex items-center gap-1 sm:gap-1.5 min-w-0">
+                  <ChevronRight className="w-4 h-4 text-gray-400 flex-shrink-0" aria-hidden="true" />
+                  <h1 aria-current="page" className="font-semibold text-gray-900 truncate">
+                    {title}
+                  </h1>
+                </li>
+              </ol>
+            </nav>
+          )}
+
+          {/* 右側（デスクトップ）：ユーザー名 + お問い合わせ + ログアウト */}
+          <nav
+            aria-label="ユーザーメニュー"
+            className="hidden sm:flex items-center gap-4 flex-shrink-0"
+          >
+            <div className="flex items-center gap-2 text-gray-700">
               <User className="w-4 h-4" aria-hidden="true" />
               <span className="text-sm">{userName}</span>
             </div>
-            {contactUrl && isValidUrl(contactUrl) && (
+            {hasContact && (
               <a
                 href={contactUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="お問い合わせ (新しいタブで開く)"
-                className="flex items-center gap-1 sm:gap-2 text-gray-700 hover:text-blue-700 transition px-2 sm:px-3 py-1.5 rounded-md hover:bg-gray-50"
+                className="flex items-center gap-2 text-gray-700 hover:text-blue-700 transition px-3 py-1.5 rounded-md hover:bg-gray-50"
               >
                 <Mail className="w-4 h-4" aria-hidden="true" />
-                <span className="hidden sm:inline text-sm">お問い合わせ</span>
+                <span className="text-sm">お問い合わせ</span>
               </a>
             )}
             <Button
@@ -81,26 +174,101 @@ export default function LoggedInHeader({
               disabled={isLoading}
               aria-busy={isLoading}
               aria-label={isLoading ? 'ログアウト中' : 'ログアウト'}
-              className="text-gray-700 hover:text-gray-900 px-2 sm:px-3"
+              className="text-gray-700 hover:text-gray-900 px-3"
             >
               {isLoading ? (
                 <Loader2 className="w-4 h-4 animate-spin motion-reduce:animate-none" aria-hidden="true" />
               ) : (
                 <LogOut className="w-4 h-4" aria-hidden="true" />
               )}
-              <span className="hidden sm:inline ml-2">
-                {isLoading ? 'ログアウト中...' : 'ログアウト'}
-              </span>
+              <span className="ml-2">{isLoading ? 'ログアウト中...' : 'ログアウト'}</span>
             </Button>
           </nav>
-        </div>
 
-        {/* モバイル用ユーザー表示 */}
-        <div className="sm:hidden flex items-center gap-2 text-gray-700 text-xs mt-2">
-          <User className="w-3 h-3" aria-hidden="true" />
-          <span>{userName}</span>
+          {/* 右側（モバイル）：ハンバーガーメニュー */}
+          <button
+            ref={menuButtonRef}
+            type="button"
+            onClick={() => setIsMenuOpen((open) => !open)}
+            aria-expanded={isMenuOpen}
+            aria-controls="mobile-menu-panel"
+            aria-label={isMenuOpen ? 'メニューを閉じる' : 'メニューを開く'}
+            className="sm:hidden flex items-center justify-center w-10 h-10 -mr-1 rounded-md text-gray-700 hover:text-gray-900 hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 flex-shrink-0"
+          >
+            {isMenuOpen ? (
+              <X className="w-6 h-6" aria-hidden="true" />
+            ) : (
+              <Menu className="w-6 h-6" aria-hidden="true" />
+            )}
+          </button>
         </div>
       </div>
+
+      {/* モバイルメニューパネル */}
+      {isMenuOpen && (
+        <div
+          ref={menuPanelRef}
+          id="mobile-menu-panel"
+          className="sm:hidden border-t border-gray-200 bg-white shadow-sm"
+        >
+          <div className="max-w-6xl mx-auto px-3 py-3">
+            <div className="flex items-center gap-2 text-gray-700 px-2 pb-3 mb-2 border-b border-gray-100">
+              <User className="w-4 h-4" aria-hidden="true" />
+              <span className="text-sm font-medium">{userName}</span>
+            </div>
+
+            <nav aria-label="メインメニュー">
+              <ul className="flex flex-col">
+                {NAV_ITEMS.map(({ href, label, icon: Icon }) => (
+                  <li key={href}>
+                    <Link
+                      href={href}
+                      onClick={() => setIsMenuOpen(false)}
+                      className="flex items-center gap-3 px-2 py-3 rounded-md text-gray-800 hover:bg-gray-50"
+                    >
+                      <Icon className="w-5 h-5 text-gray-500" aria-hidden="true" />
+                      <span className="text-sm">{label}</span>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </nav>
+
+            <div className="mt-2 pt-2 border-t border-gray-100 flex flex-col">
+              {hasContact && (
+                <a
+                  href={contactUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={() => setIsMenuOpen(false)}
+                  aria-label="お問い合わせ (新しいタブで開く)"
+                  className="flex items-center gap-3 px-2 py-3 rounded-md text-gray-800 hover:bg-gray-50"
+                >
+                  <Mail className="w-5 h-5 text-gray-500" aria-hidden="true" />
+                  <span className="text-sm">お問い合わせ</span>
+                </a>
+              )}
+              <button
+                type="button"
+                onClick={() => {
+                  setIsMenuOpen(false);
+                  void handleSignOut();
+                }}
+                disabled={isLoading}
+                aria-busy={isLoading}
+                className="flex items-center gap-3 px-2 py-3 rounded-md text-gray-800 hover:bg-gray-50 disabled:opacity-50 text-left"
+              >
+                {isLoading ? (
+                  <Loader2 className="w-5 h-5 text-gray-500 animate-spin motion-reduce:animate-none" aria-hidden="true" />
+                ) : (
+                  <LogOut className="w-5 h-5 text-gray-500" aria-hidden="true" />
+                )}
+                <span className="text-sm">{isLoading ? 'ログアウト中...' : 'ログアウト'}</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </header>
   );
 }

--- a/src/components/layout/Header/LoggedInHeader.tsx
+++ b/src/components/layout/Header/LoggedInHeader.tsx
@@ -20,7 +20,7 @@ import { isValidUrl } from '@/utils/urlValidation';
 const BRAND = 'ReflectHub';
 const HOME_HREF = '/dashboard';
 
-interface Breadcrumb {
+export interface Breadcrumb {
   label: string;
   href?: string;
 }
@@ -53,6 +53,7 @@ export default function LoggedInHeader({
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const menuButtonRef = useRef<HTMLButtonElement>(null);
   const menuPanelRef = useRef<HTMLDivElement>(null);
+  const firstMenuItemRef = useRef<HTMLAnchorElement>(null);
 
   const isHome = title === BRAND && breadcrumbs.length === 0;
   const hasContact = contactUrl != null && isValidUrl(contactUrl);
@@ -61,6 +62,9 @@ export default function LoggedInHeader({
     setIsLoading(true);
     try {
       await onSignOut();
+    } catch {
+      // onSignOut のエラーは呼び出し元で処理される想定。
+      // ここで握りつぶすことで未処理のPromiseRejectionをUIに伝播させない。
     } finally {
       setIsLoading(false);
     }
@@ -69,6 +73,9 @@ export default function LoggedInHeader({
   // メニュー: Escape で閉じてトリガーにフォーカスを戻す + 外側クリックで閉じる
   useEffect(() => {
     if (!isMenuOpen) return;
+
+    // 開いたら最初のメニュー項目へフォーカスを移す（開示パターンの定石）
+    queueMicrotask(() => firstMenuItemRef.current?.focus());
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
@@ -178,9 +185,10 @@ export default function LoggedInHeader({
 
                 <nav aria-label="メインメニュー">
                   <ul className="flex flex-col">
-                    {NAV_ITEMS.map(({ href, label, icon: Icon }) => (
+                    {NAV_ITEMS.map(({ href, label, icon: Icon }, index) => (
                       <li key={href}>
                         <Link
+                          ref={index === 0 ? firstMenuItemRef : undefined}
                           href={href}
                           onClick={closeMenu}
                           className="flex items-center gap-3 px-4 py-2.5 text-gray-800 hover:bg-gray-50"

--- a/src/components/layout/Header/index.tsx
+++ b/src/components/layout/Header/index.tsx
@@ -1,12 +1,7 @@
 'use client';
 
-import LoggedInHeader from './LoggedInHeader';
+import LoggedInHeader, { type Breadcrumb } from './LoggedInHeader';
 import LoggedOutHeader from './LoggedOutHeader';
-
-interface Breadcrumb {
-  label: string;
-  href?: string;
-}
 
 interface HeaderProps {
   isAuthenticated: boolean;

--- a/src/components/layout/Header/index.tsx
+++ b/src/components/layout/Header/index.tsx
@@ -3,13 +3,17 @@
 import LoggedInHeader from './LoggedInHeader';
 import LoggedOutHeader from './LoggedOutHeader';
 
+interface Breadcrumb {
+  label: string;
+  href?: string;
+}
+
 interface HeaderProps {
   isAuthenticated: boolean;
   userName?: string;
   onSignOut?: () => Promise<void>;
   title?: string;
-  showBackButton?: boolean;
-  backHref?: string;
+  breadcrumbs?: Breadcrumb[];
   contactUrl?: string;
 }
 
@@ -18,8 +22,7 @@ export default function Header({
   userName,
   onSignOut,
   title = 'ReflectHub',
-  showBackButton = false,
-  backHref = '/dashboard',
+  breadcrumbs,
   contactUrl
 }: HeaderProps) {
   if (isAuthenticated && userName != null && onSignOut) {
@@ -28,8 +31,7 @@ export default function Header({
         userName={userName}
         onSignOut={onSignOut}
         title={title}
-        showBackButton={showBackButton}
-        backHref={backHref}
+        breadcrumbs={breadcrumbs}
         contactUrl={contactUrl}
       />
     );


### PR DESCRIPTION
## 概要
詳細ページなど深い階層で「戻る」ボタンを連打しないとトップに戻れず、ヘッダーが「戻る＋ページ名」だけで導線が乏しかった問題を解消するため、ヘッダーのナビゲーションを刷新しました。

## 変更内容
- **ロゴ「ReflectHub」を常にダッシュボードへのリンク化**し、どのページからでも一発でトップに戻れるようにした
- **深い階層でパンくずを表示**（例: `ReflectHub / 振り返り履歴 / 振り返り詳細`）し、各階層へ直接移動できるようにした（戻る連打の解消）
- **メニューボタン(☰)を全ビューポート共通に統一**。モバイルはもちろん、PC でも右上にコンパクトなドロップダウンとして開くようにし、主要ページ（新しい振り返り / 履歴 / 統計 / 設定）＋お問い合わせ＋ログアウトをグローバルナビとして集約
- 各ページの `showBackButton` / `backHref` を `breadcrumbs` ベースに置き換え（`Header` / `LoggedInHeader`）
- メニューは `aria-expanded` / Escape で閉じてフォーカス復帰 / 外側クリックで閉じる、などアクセシビリティに配慮

## 動機・背景
ダッシュボード → 履歴 → 詳細 と2階層深く、詳細ページの「戻る」は `/history` に1階層戻るだけだったため、トップへ戻るには「戻る」を2回押す必要があった。また、履歴↔統計のような横移動の導線がヘッダーに無く、移動は基本ダッシュボードのカード経由に限られていた。ロゴのホームリンク化・パンくず・共通メニューにより、これらをアプリ全体で解決する。

## テスト
- [x] ユニットテスト
- [ ] 統合テスト
- [x] 手動テスト

`vitest` で詳細ページ・プロフィールページのテストが通ることを確認（計14件パス）。加えて、実際の `LoggedInHeader` を Next.js dev サーバーで描画し、Playwright で PC/スマホの表示とメニュー開閉（`aria-expanded` とパネル表示）を目視・自動で確認済み。

## スクリーンショット
チャット上で PC（パンくず＋☰、メニュー展開時のドロップダウン）／スマホ（パンくず＋☰、メニュー展開）の各状態を確認済みです。

## チェックリスト
- [x] pnpm lint:fixを行った
- [ ] CodeRabbitで問題がない
- [ ] `pnpm run build`で問題が出ない
- [ ] Vercel botで問題が出ない
- [x] テストが通る
- [ ] ドキュメントを更新した（必要に応じて）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ysATKQXHwLV11uYasKbGe

---
_Generated by [Claude Code](https://claude.ai/code/session_016ysATKQXHwLV11uYasKbGe)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added breadcrumb navigation to signed-in page headers, making it easier to understand where you are in the app.
  * Updated the header menu to include quick links, your account name, contact access when available, and sign-out.

* **Bug Fixes**
  * Removed inconsistent back-button behavior from several pages so header navigation is more predictable.
  * Improved contact link handling so it only appears when a valid link is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->