### PR TITLE
feat(header): ハンバーガーメニューをスマホ・タブレットのみに変更

### DIFF
--- a/src/components/layout/Header/LoggedInHeader.tsx
+++ b/src/components/layout/Header/LoggedInHeader.tsx
@@ -269,10 +269,7 @@ export default function LoggedInHeader({
                   )}
                   <button
                     type="button"
-                    onClick={() => {
-                      closeMenu();
-                      void handleSignOut();
-                    }}
+                    onClick={() => void handleSignOut()}
                     disabled={isLoading}
                     aria-busy={isLoading}
                     className="flex items-center gap-3 px-4 py-2.5 text-gray-800 hover:bg-gray-50 disabled:opacity-50 text-left"

--- a/src/components/layout/Header/LoggedInHeader.tsx
+++ b/src/components/layout/Header/LoggedInHeader.tsx
@@ -154,8 +154,60 @@ export default function LoggedInHeader({
             </nav>
           )}
 
-          {/* 右側：メニューボタン（全画面共通）+ ドロップダウン */}
-          <div className="relative flex-shrink-0">
+          {/* 右側（デスクトップ）：横並びナビ。xl 未満（スマホ・タブレット）は非表示 */}
+          <nav
+            aria-label="メインメニュー"
+            className="hidden xl:flex items-center gap-1 flex-shrink-0"
+          >
+            {NAV_ITEMS.map(({ href, label, icon: Icon }) => (
+              <Link
+                key={href}
+                href={href}
+                className="flex items-center gap-1.5 px-3 py-2 rounded-md text-sm text-gray-700 hover:text-gray-900 hover:bg-gray-50"
+              >
+                <Icon className="w-4 h-4 text-gray-500 flex-shrink-0" aria-hidden="true" />
+                <span>{label}</span>
+              </Link>
+            ))}
+
+            {hasContact && (
+              <a
+                href={contactUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="お問い合わせ (新しいタブで開く)"
+                className="flex items-center gap-1.5 px-3 py-2 rounded-md text-sm text-gray-700 hover:text-gray-900 hover:bg-gray-50"
+              >
+                <Mail className="w-4 h-4 text-gray-500 flex-shrink-0" aria-hidden="true" />
+                <span>お問い合わせ</span>
+              </a>
+            )}
+
+            <div className="mx-1 h-6 w-px bg-gray-200" aria-hidden="true" />
+
+            <div className="flex items-center gap-1.5 px-2 text-gray-700">
+              <User className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
+              <span className="text-sm font-medium max-w-[8rem] truncate">{userName}</span>
+            </div>
+
+            <button
+              type="button"
+              onClick={() => void handleSignOut()}
+              disabled={isLoading}
+              aria-busy={isLoading}
+              className="flex items-center gap-1.5 px-3 py-2 rounded-md text-sm text-gray-700 hover:text-gray-900 hover:bg-gray-50 disabled:opacity-50"
+            >
+              {isLoading ? (
+                <Loader2 className="w-4 h-4 text-gray-500 animate-spin motion-reduce:animate-none flex-shrink-0" aria-hidden="true" />
+              ) : (
+                <LogOut className="w-4 h-4 text-gray-500 flex-shrink-0" aria-hidden="true" />
+              )}
+              <span>{isLoading ? 'ログアウト中...' : 'ログアウト'}</span>
+            </button>
+          </nav>
+
+          {/* 右側（スマホ・タブレット）：ハンバーガーメニュー + ドロップダウン。xl 以上は非表示 */}
+          <div className="relative flex-shrink-0 xl:hidden">
             <button
               ref={menuButtonRef}
               type="button"


### PR DESCRIPTION
## 概要
ログイン後ヘッダーで、PC（デスクトップ）でもハンバーガーメニューが表示されるのは不自然だったため、ハンバーガーメニューをスマホ・タブレットのみの表示にし、PC ではナビゲーションを横並びで直接表示するように変更しました。

## 変更内容
- `xl`（1280px）以上のデスクトップでは、ナビ項目（新しい振り返り・履歴・統計・設定）・お問い合わせ・ユーザー名・ログアウトを横並びで直接表示
- `xl` 未満（スマホ・iPad）では従来通りハンバーガーメニュー（ドロップダウン）を表示
- ブレークポイントは `lg`(1024px) ではなく `xl`(1280px) を採用し、iPad 横向き（1024px）もハンバーガー側に含めた

## 動機・背景
PC でハンバーガーメニューが表示されるのは UI として不自然で、横幅に余裕のある画面ではナビを直接見せた方が使いやすいため。iPad などタブレットまではハンバーガーが適切という判断で、切り替え境界を `xl` に設定した。

## テスト
- [ ] ユニットテスト
- [ ] 統合テスト
- [x] 手動テスト（型チェック・ESLint クリーン、`next build` のコンパイル成功を確認）

## スクリーンショット
<!-- UI変更がある場合は画像を添付 -->

## チェックリスト
- [x] lint を行った（ESLint クリーン）
- [ ] CodeRabbitで問題がない
- [x] `build`で問題が出ない（コンパイル成功を確認）
- [ ] Vercel botで問題が出ない
- [ ] テストが通る
- [ ] ドキュメントを更新した（必要に応じて）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFtFLZ2HH2yw7h8hM5BvLA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated desktop navigation layout for signed-in users on larger screens.
  * Inline navigation links now appear in the header, along with the user name and a logout button.
  * The header can now show an external contact link when available.

* **Bug Fixes**
  * Improved responsive behavior by separating desktop navigation from the mobile menu, making the header easier to use across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->