### PR TITLE
perf: 認証初期化を1往復に短縮してトップページ初回表示を高速化

### DIFF
--- a/src/app/api/auth/verify/route.ts
+++ b/src/app/api/auth/verify/route.ts
@@ -22,11 +22,43 @@ export async function GET() {
       // (/api/auth/session POST) に作成済みで、RLS により自分の行のみ取得
       // される。取得に失敗しても認証自体は成立しているので、profile は
       // null で返し、クライアント側は session.user 情報でフォールバックする。
-      const { data: profile } = await supabase
+      const { data: profile, error: profileError } = await supabase
         .from('profiles')
         .select('*')
         .eq('id', session.user.id)
         .single();
+
+      let resolvedProfile = profile ?? null;
+
+      // プロフィール行が存在しない (PGRST116 = 0 行) 場合は、従来
+      // initialize が叩いていた /api/auth/profile/{id} GET の create-on-miss
+      // と同じ自己修復をここで行う。これが無いと、ログイン時の
+      // /api/auth/session insert が失敗して握り潰された等でプロフィール行が
+      // 無いユーザーが、合成名のまま初期化され、プロフィールページを開くまで
+      // 行が作られない状態になる。
+      if (!resolvedProfile && profileError?.code === 'PGRST116') {
+        const meta = session.user.user_metadata ?? {};
+        const name =
+          meta.full_name ||
+          meta.name ||
+          session.user.email?.split('@')[0] ||
+          'ユーザー';
+
+        const { data: createdProfile } = await supabase
+          .from('profiles')
+          .insert({
+            id: session.user.id,
+            email: session.user.email,
+            name,
+            provider: 'google',
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          })
+          .select()
+          .single();
+
+        resolvedProfile = createdProfile ?? null;
+      }
 
       return NextResponse.json({
         authenticated: true,
@@ -34,7 +66,7 @@ export async function GET() {
           id: session.user.id,
           email: session.user.email,
         },
-        profile: profile ?? null,
+        profile: resolvedProfile,
       });
     }
 

--- a/src/app/api/auth/verify/route.ts
+++ b/src/app/api/auth/verify/route.ts
@@ -16,12 +16,25 @@ export async function GET() {
     }
 
     if (session?.user) {
+      // クライアントの初期化 (authStore.initialize) が verify に続けて
+      // /api/auth/profile/{id} を直列で叩いていた 2 往復を 1 往復に短縮する
+      // ため、ここでプロフィールも一緒に返す。プロフィールはログイン時
+      // (/api/auth/session POST) に作成済みで、RLS により自分の行のみ取得
+      // される。取得に失敗しても認証自体は成立しているので、profile は
+      // null で返し、クライアント側は session.user 情報でフォールバックする。
+      const { data: profile } = await supabase
+        .from('profiles')
+        .select('*')
+        .eq('id', session.user.id)
+        .single();
+
       return NextResponse.json({
         authenticated: true,
         user: {
           id: session.user.id,
           email: session.user.email,
-        }
+        },
+        profile: profile ?? null,
       });
     }
 

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -70,7 +70,8 @@ describe("authStore - Loading State and Timeout Management", () => {
     );
 
     it("should set isLoading to false when fetch succeeds quickly", async () => {
-      // Mock successful response
+      // /api/auth/verify がプロフィールも同梱して返すため、初期化は 1 回の
+      // fetch で完結する (verify → profile の 2 往復ではない)。
       (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
         ok: true,
         json: async () => ({
@@ -79,13 +80,6 @@ describe("authStore - Loading State and Timeout Management", () => {
             id: "test-user-id",
             email: "test@example.com",
           },
-        }),
-      } as Response);
-
-      // Mock profile fetch
-      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
           profile: {
             id: "test-user-id",
             email: "test@example.com",
@@ -108,6 +102,9 @@ describe("authStore - Loading State and Timeout Management", () => {
       expect(state.isAuthenticated).toBe(true);
       expect(state.error).toBeNull();
       expect(state.user).toBeDefined();
+      expect(state.user?.name).toBe("Test User");
+      // 認証確認 1 回のみで完結していること (追加のプロフィール取得なし)
+      expect(global.fetch).toHaveBeenCalledTimes(1);
     });
 
     it("should handle network errors and set isLoading to false", async () => {

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -197,43 +197,30 @@ export const useAuthStore = create<AuthStore>()(
             const serverSession = await serverSessionResponse.json();
 
             if (serverSession.authenticated) {
-              try {
-                const profileResponse = await fetchWithTimeout(
-                  `/api/auth/profile/${serverSession.user.id}`,
-                  {
-                    method: "GET",
-                    credentials: "include",
-                  },
-                  30000
-                );
+              // /api/auth/verify がプロフィールも同梱して返すため、以前の
+              // ように /api/auth/profile/{id} を追加で叩く必要はない
+              // (verify → profile の 2 往復を 1 往復に短縮)。プロフィールが
+              // 取得できなかった場合は下の session.user 情報でフォールバック。
+              const serverProfile = serverSession.profile;
+              if (serverProfile) {
+                const user: User = {
+                  id: serverProfile.id,
+                  email: serverProfile.email,
+                  name: serverProfile.name,
+                  provider: serverProfile.provider,
+                  avatar_url: serverProfile.avatar_url,
+                  line_user_id: serverProfile.line_user_id,
+                  created_at: serverProfile.created_at,
+                  updated_at: serverProfile.updated_at,
+                };
 
-                if (profileResponse.ok) {
-                  const profileData = await profileResponse.json();
-
-                  if (profileData.profile) {
-                    const user: User = {
-                      id: profileData.profile.id,
-                      email: profileData.profile.email,
-                      name: profileData.profile.name,
-                      provider: profileData.profile.provider,
-                      avatar_url: profileData.profile.avatar_url,
-                      line_user_id: profileData.profile.line_user_id,
-                      created_at: profileData.profile.created_at,
-                      updated_at: profileData.profile.updated_at,
-                    };
-
-                    set({
-                      user,
-                      isAuthenticated: true,
-                      isLoading: false,
-                      error: null,
-                    });
-                    return;
-                  }
-                }
-              } catch (profileError) {
-                // Profile check error is non-critical
-                console.error("Profile fetch error:", profileError);
+                set({
+                  user,
+                  isAuthenticated: true,
+                  isLoading: false,
+                  error: null,
+                });
+                return;
               }
 
               const user: User = {


### PR DESCRIPTION
## 概要
ログイン済みでトップページ（`/`）を開いた際の初回表示を高速化する。認証初期化での **verify → profile の2往復（直列）を1往復に短縮** した。

Closes #115

## 変更内容
- `src/app/api/auth/verify/route.ts`: 認証済みレスポンスに `profile` を同梱（1クエリ追加のみで往復数は不変）
- `src/stores/authStore.ts`: `initialize()` が `/api/auth/verify` の1往復のみで完結するよう変更し、`/api/auth/profile/{id}` への2回目の fetch を廃止。プロフィールが取得できない場合は従来どおり `session.user` 情報でフォールバック
- `src/stores/authStore.test.ts`: 新挙動（verifyがprofileを同梱し、fetchは1回のみ）に合わせてテストを更新

## 動機・背景
ログイン済みの状態でトップページを開くと、`isLoading` が `true` の間はスピナー「読み込み中...」だけが表示される。`authStore.initialize()`（`src/stores/authStore.ts`）が `GET /api/auth/verify` → `GET /api/auth/profile/{id}` を **2回のネットワーク往復を直列**（各最大30秒タイムアウト）で実行しており、コールドスタートや低速回線ではスピナー表示が長引いていた。ログイン済みユーザーはその後 `/dashboard` へリダイレクトされるため、この待ち時間がそのまま初回表示の遅延として体感される。

プロフィールはログイン時（`/api/auth/session` POST）に作成済みで、`verify` 内で1クエリ取得して返せるため、2往復を1往復に統合できる。`/api/auth/profile/{userId}` エンドポイント自体はプロフィール画面で引き続き利用するため残している。

## テスト
- [x] ユニットテスト（`authStore.test.ts` / `api/auth` / `useSessionManager.test.ts` 通過）
- [ ] 統合テスト
- [ ] 手動テスト

補足: 変更ファイルの ESLint はパス。`tsc --noEmit` で出る型エラーは既存テストファイル由来で本変更とは無関係。

## スクリーンショット
なし（UI変更なし）

## チェックリスト
- [x] pnpm lint:fixを行った（変更ファイルのlintパス）
- [ ] CodeRabbitで問題がない
- [ ] `pnpm run build`で問題が出ない
- [ ] Vercel botで問題が出ない
- [x] テストが通る
- [ ] ドキュメントを更新した（必要に応じて）

## 補足（別Issue候補）
- `/` をログイン済み時に middleware でサーバーリダイレクトし、クライアント側の `/`→`/dashboard` 遷移を省く
- 未ログイン向けのランディング即表示（`isLoading` ゲートの撤廃）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QdD44w7jf48VUV1qDpCEV9

---
_Generated by [Claude Code](https://claude.ai/code/session_01QdD44w7jf48VUV1qDpCEV9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication verification now includes the user’s profile information in the response.
  * User details, including profile name and account metadata, load during a single authentication check.

* **Bug Fixes**
  * Reduced unnecessary profile requests during sign-in initialization.
  * Authentication remains successful when profile information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->